### PR TITLE
Rpm build updates

### DIFF
--- a/bin/build_pipeline_heka.sh
+++ b/bin/build_pipeline_heka.sh
@@ -26,11 +26,11 @@ if [ ! -f "patches_applied" ]; then
     echo "Patching for larger message size"
     patch message/message.go < $BASE/heka/patches/0001-Increase-message-size-limit-from-64KB-to-8MB.patch
 
-    echo "Patching to build `heka-export` cmd"
+    echo 'Patching to build `heka-export` cmd'
     patch CMakeLists.txt < $BASE/heka/patches/0002-Add-cmdline-tool-for-uploading-to-S3.patch
 
     # TODO: do this using cmake externals instead of shell-fu.
-    echo "Installing source files for `heka-export` cmd"
+    echo 'Installing source files for `heka-export` cmd'
     cp -R $BASE/heka/cmd/heka-export ./cmd/
 
     echo "Adding external plugin for s3splitfile output"

--- a/bin/build_pipeline_heka.sh
+++ b/bin/build_pipeline_heka.sh
@@ -4,7 +4,7 @@
 set -o errexit
 
 # Machine config:
-# sudo yum install -y git hg golang cmake rpmdevtools GeoIP-devel
+# sudo yum install -y git hg golang cmake rpmdevtools GeoIP-devel rpmrebuild
 
 BASE=$(pwd)
 
@@ -44,3 +44,7 @@ source build.sh
 
 # Build RPM
 make package
+if hash rpmrebuild 2>/dev/null; then
+    echo "Rebuilding RPM with date iteration and svc suffix"
+    rpmrebuild -d . --release=0.$(date +%Y%m%d)svc -p -n heka-*-linux-amd64.rpm
+fi

--- a/bin/build_pipeline_heka.sh
+++ b/bin/build_pipeline_heka.sh
@@ -33,6 +33,9 @@ if [ ! -f "patches_applied" ]; then
     echo 'Installing source files for `heka-export` cmd'
     cp -R $BASE/heka/cmd/heka-export ./cmd/
 
+    echo 'Installing lua filters/modules/decoders'
+    rsync -vr $BASE/heka/sandbox/ ./sandbox/lua/
+
     echo "Adding external plugin for s3splitfile output"
     echo 'add_external_plugin(git https://github.com/mreid-moz/data-pipeline master heka/plugins/s3splitfile __ignore_root)' >> cmake/plugin_loader.cmake
 fi


### PR DESCRIPTION
`rpmrebuild` is available in Fedora but doesn't seem to ship with CentOS/EPEL, so its execution is predicated on its existence. I'm hoping we can do away with this when all is converted to CMake (but it may require some serious CMake vodoo).

Also bake the filters from this repo into the resulting RPM.
