### PR TITLE
Use aws.GetAuth for IAM credentials when available.

### DIFF
--- a/heka/cmd/heka-export/main.go
+++ b/heka/cmd/heka-export/main.go
@@ -14,18 +14,18 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/crowdmob/goamz/aws"
+	"github.com/crowdmob/goamz/s3"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
-	"github.com/crowdmob/goamz/aws"
-	"github.com/crowdmob/goamz/s3"
 )
 
 type Progress struct {
-	Count int64
-	Bytes int64
+	Count  int64
+	Bytes  int64
 	Errors int32
 }
 
@@ -113,17 +113,16 @@ func makeupload(base string, pattern *regexp.Regexp, bucket *s3.Bucket, bucketPr
 	}
 }
 
-
 func main() {
-    flagBase := flag.String("base-dir", "/", "Base directory in which to look for files to export")
-    flagPattern := flag.String("pattern", ".*", "Filenames must match this regular expression to be uploaded")
-    flagBucket := flag.String("bucket", "default-bucket", "S3 Bucket name")
-    flagBucketPrefix := flag.String("bucket-prefix", "", "S3 Bucket path prefix")
-    flagAWSKey := flag.String("aws-key", "DUMMY", "AWS Key")
-    flagAWSSecretKey := flag.String("aws-secret-key", "DUMMY", "AWS Secret Key")
-    flagAWSRegion := flag.String("aws-region", "us-west-2", "AWS Region")
-    flagLoop := flag.Bool("loop", false, "Run in a loop and keep watching for more files to export")
-    flagDryRun := flag.Bool("dry-run", false, "Don't actually do anything, just output what would be done")
+	flagBase := flag.String("base-dir", "/", "Base directory in which to look for files to export")
+	flagPattern := flag.String("pattern", ".*", "Filenames must match this regular expression to be uploaded")
+	flagBucket := flag.String("bucket", "default-bucket", "S3 Bucket name")
+	flagBucketPrefix := flag.String("bucket-prefix", "", "S3 Bucket path prefix")
+	flagAWSKey := flag.String("aws-key", "", "AWS Key")
+	flagAWSSecretKey := flag.String("aws-secret-key", "", "AWS Secret Key")
+	flagAWSRegion := flag.String("aws-region", "us-west-2", "AWS Region")
+	flagLoop := flag.Bool("loop", false, "Run in a loop and keep watching for more files to export")
+	flagDryRun := flag.Bool("dry-run", false, "Don't actually do anything, just output what would be done")
 	flag.Parse()
 
 	if flag.NArg() != 0 {
@@ -153,8 +152,18 @@ func main() {
 
 	var b *s3.Bucket
 	if !*flagDryRun {
-		auth := aws.Auth{AccessKey: *flagAWSKey, SecretKey: *flagAWSSecretKey}
-		s := s3.New(auth, aws.Regions[*flagAWSRegion])
+		auth, err := aws.GetAuth(*flagAWSKey, *flagAWSSecretKey, "", time.Now())
+		if err != nil {
+			fmt.Printf("Authentication error: %s\n", err)
+			os.Exit(4)
+		}
+
+		region, ok := aws.Regions[*flagAWSRegion]
+		if !ok {
+			fmt.Printf("Parameter 'aws-region' must be a valid AWS Region\n")
+			os.Exit(5)
+		}
+		s := s3.New(auth, region)
 		b = s.Bucket(*flagBucket)
 	} else {
 		// b declared and not used :(

--- a/heka/cmd/heka-s3cat/main.go
+++ b/heka/cmd/heka-s3cat/main.go
@@ -33,8 +33,8 @@ func main() {
 	flagOutput := flag.String("output", "", "output filename, defaults to stdout")
 	flagStdin := flag.Bool("stdin", false, "read list of s3 key names from stdin")
 	flagBucket := flag.String("bucket", "default-bucket", "S3 Bucket name")
-	flagAWSKey := flag.String("aws-key", "DUMMY", "AWS Key")
-	flagAWSSecretKey := flag.String("aws-secret-key", "DUMMY", "AWS Secret Key")
+	flagAWSKey := flag.String("aws-key", "", "AWS Key")
+	flagAWSSecretKey := flag.String("aws-secret-key", "", "AWS Secret Key")
 	flagAWSRegion := flag.String("aws-region", "us-west-2", "AWS Region")
 	flag.Parse()
 
@@ -61,11 +61,15 @@ func main() {
 		defer out.Close()
 	}
 
-	auth := aws.Auth{AccessKey: *flagAWSKey, SecretKey: *flagAWSSecretKey}
+	auth, err := aws.GetAuth(*flagAWSKey, *flagAWSSecretKey, "", time.Now())
+	if err != nil {
+		fmt.Printf("Authentication error: %s\n", err)
+		os.Exit(4)
+	}
 	region, ok := aws.Regions[*flagAWSRegion]
 	if !ok {
 		fmt.Printf("Parameter 'aws-region' must be a valid AWS Region\n")
-		os.Exit(4)
+		os.Exit(5)
 	}
 	s := s3.New(auth, region)
 	bucket := s.Bucket(*flagBucket)

--- a/heka/cmd/heka-s3list/main.go
+++ b/heka/cmd/heka-s3list/main.go
@@ -26,8 +26,8 @@ func main() {
 	flagSchema := flag.String("schema", "", "Filename of the schema to use as a filter")
 	flagBucket := flag.String("bucket", "default-bucket", "S3 Bucket name")
 	flagBucketPrefix := flag.String("bucket-prefix", "", "S3 Bucket path prefix")
-	flagAWSKey := flag.String("aws-key", "DUMMY", "AWS Key")
-	flagAWSSecretKey := flag.String("aws-secret-key", "DUMMY", "AWS Secret Key")
+	flagAWSKey := flag.String("aws-key", "", "AWS Key")
+	flagAWSSecretKey := flag.String("aws-secret-key", "", "AWS Secret Key")
 	flagAWSRegion := flag.String("aws-region", "us-west-2", "AWS Region")
 	flagDryRun := flag.Bool("dry-run", false, "Don't actually do anything, just output what would be done")
 	flagVerbose := flag.Bool("verbose", false, "Print detailed info")
@@ -60,11 +60,15 @@ func main() {
 	}
 
 	// Initialize the S3 bucket
-	auth := aws.Auth{AccessKey: *flagAWSKey, SecretKey: *flagAWSSecretKey}
+	auth, err := aws.GetAuth(*flagAWSKey, *flagAWSSecretKey, "", time.Now())
+	if err != nil {
+		fmt.Printf("Authentication error: %s\n", err)
+		os.Exit(4)
+	}
 	region, ok := aws.Regions[*flagAWSRegion]
 	if !ok {
 		fmt.Printf("Parameter 'aws-region' must be a valid AWS Region\n")
-		os.Exit(4)
+		os.Exit(5)
 	}
 	s := s3.New(auth, region)
 	b = s.Bucket(*flagBucket)

--- a/heka/plugins/s3splitfile/s3splitfile_input.go
+++ b/heka/plugins/s3splitfile/s3splitfile_input.go
@@ -65,7 +65,10 @@ func (input *S3SplitFileInput) Init(config interface{}) (err error) {
 	}
 
 	if conf.S3Bucket != "" {
-		auth := aws.Auth{AccessKey: conf.AWSKey, SecretKey: conf.AWSSecretKey}
+		auth, err := aws.GetAuth(conf.AWSKey, conf.AWSSecretKey, "", time.Now())
+		if err != nil {
+			return fmt.Errorf("Authentication error: %s\n", err)
+		}
 		region, ok := aws.Regions[conf.AWSRegion]
 		if !ok {
 			return fmt.Errorf("Parameter 'aws_region' must be a valid AWS Region")

--- a/heka/plugins/s3splitfile/s3splitfile_output.go
+++ b/heka/plugins/s3splitfile/s3splitfile_output.go
@@ -154,7 +154,10 @@ func (o *S3SplitFileOutput) Init(config interface{}) (err error) {
 	}
 
 	if conf.S3Bucket != "" {
-		auth := aws.Auth{AccessKey: conf.AWSKey, SecretKey: conf.AWSSecretKey}
+		auth, err := aws.GetAuth(conf.AWSKey, conf.AWSSecretKey, "", time.Now())
+		if err != nil {
+			return fmt.Errorf("Authentication error: %s\n", err)
+		}
 		region, ok := aws.Regions[conf.AWSRegion]
 		if !ok {
 			return fmt.Errorf("Parameter 'aws_region' must be a valid AWS Region")


### PR DESCRIPTION
Use `GetAuth` to take advantage of environment variables and IAM credentials, if available, so that we don't need to hard-code credentials on instances anymore.

There's some gofmt spam, but salient changes are:

Default empty strings for command line tools key / secret key flags (if unspecified attempt to use IAM creds).

I added the bad region failure code from `heka-s3cat` to `heka-export` so that they maintain the same error codes. Exit 4 is now "authentication error" and 5 "bad region".

@mreid-moz r?
