### PR TITLE
Wrap the inject_message in pcall for safety.

### DIFF
--- a/heka/sandbox/decoders/extract_telemetry_dimensions.lua
+++ b/heka/sandbox/decoders/extract_telemetry_dimensions.lua
@@ -116,6 +116,10 @@ function process_message()
     msg.Fields.sampleId = sample(msg.Fields.clientId, 100)
 
     -- Send new message along.
-    inject_message(msg)
+    local err
+    ok, err = pcall(inject_message, msg)
+    if not ok then
+        return -1, err
+    end
     return 0
 end

--- a/heka/sandbox/decoders/extract_telemetry_dimensions.lua
+++ b/heka/sandbox/decoders/extract_telemetry_dimensions.lua
@@ -45,6 +45,11 @@ function process_message()
     local ok
     ok, msg.Payload = uncompress(read_message("Payload"))
     if not ok then return -1, msg.Payload end
+    -- This size check should match the output_limit config param. We want to
+    -- check the size early to avoid parsing JSON if we don't have to.
+    if string.len(msg.Payload) > 2097152 then
+        return -1, "Uncompressed Payload too large: " .. string.len(msg.Payload)
+    end
 
     -- Attempt to parse the payload as JSON.
     local parsed


### PR DESCRIPTION
We don't want the decoder to fail on oversized messages.
