### PR TITLE
Add a max-message-size parameter for heka-s3cat

### DIFF
--- a/heka/cmd/heka-s3cat/main.go
+++ b/heka/cmd/heka-s3cat/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mozilla-services/data-pipeline/heka/plugins/s3splitfile"
 	"github.com/mozilla-services/heka/message"
 	"io"
+	"math"
 	"os"
 	"time"
 )
@@ -44,7 +45,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if *flagMaxMessageSize < uint64(4294967295) {
+	if *flagMaxMessageSize < math.MaxUint32 {
 		maxSize := uint32(*flagMaxMessageSize)
 		message.SetMaxMessageSize(maxSize)
 	} else {

--- a/heka/cmd/heka-s3cat/main.go
+++ b/heka/cmd/heka-s3cat/main.go
@@ -36,11 +36,20 @@ func main() {
 	flagAWSKey := flag.String("aws-key", "", "AWS Key")
 	flagAWSSecretKey := flag.String("aws-secret-key", "", "AWS Secret Key")
 	flagAWSRegion := flag.String("aws-region", "us-west-2", "AWS Region")
+	flagMaxMessageSize := flag.Uint64("max-message-size", 4*1024*1024, "maximum message size in bytes")
 	flag.Parse()
 
 	if !*flagStdin && flag.NArg() < 1 {
 		flag.PrintDefaults()
 		os.Exit(1)
+	}
+
+	if *flagMaxMessageSize < uint64(4294967295) {
+		maxSize := uint32(*flagMaxMessageSize)
+		message.SetMaxMessageSize(maxSize)
+	} else {
+		fmt.Printf("Message size is too large: %d\n", flagMaxMessageSize)
+		os.Exit(8)
 	}
 
 	var err error


### PR DESCRIPTION
This is the same change as made to heka-cat in [Heka PR 1373](https://github.com/mozilla-services/heka/pull/1373).
