### PR TITLE
Include the "DNT" and "Date" fields.

### DIFF
--- a/examples/basic_local_pipeline.toml
+++ b/examples/basic_local_pipeline.toml
@@ -9,7 +9,7 @@ max_message_size = 8388608
 [TestInput]
 type = "HttpListenInput"
 address = "127.0.0.1:8080"
-request_headers = ["Content-Length", "X-Forwarded-For", "DNT"]
+request_headers = ["Content-Length", "X-Forwarded-For", "DNT", "Date"]
 decoder = "HttpEdgeDecoder"
 send_decode_failures = true
 

--- a/heka/sandbox/decoders/extract_telemetry_dimensions.lua
+++ b/heka/sandbox/decoders/extract_telemetry_dimensions.lua
@@ -196,6 +196,7 @@ function process_message()
     msg.Timestamp         = read_message("Timestamp")
     msg.Fields.Host       = read_message("Fields[Host]")
     msg.Fields.DNT        = read_message("Fields[DNT]")
+    msg.Fields.clientDate = read_message("Fields[Date]")
 
     msg.Fields.submissionDate = os.date("%Y%m%d", msg.Timestamp / 1e9)
 

--- a/heka/sandbox/decoders/http_edge_decoder.lua
+++ b/heka/sandbox/decoders/http_edge_decoder.lua
@@ -115,8 +115,10 @@ function process_message()
     -- Note: 'Hostname' is the host name of the server that received the
     -- message, while 'Host' is the name of the HTTP endpoint the client
     -- used (such as "incoming.telemetry.mozilla.org").
-    main_msg.Hostname = landfill_msg.Hostname
+    main_msg.Hostname    = landfill_msg.Hostname
     main_msg.Fields.Host = landfill_msg.Fields.Host
+    main_msg.Fields.DNT  = landfill_msg.Fields.DNT
+    main_msg.Fields.Date = landfill_msg.Fields.Date
 
     -- Path should be of the form:
     --     ^/submit/namespace/id[/extra/path/components]$


### PR DESCRIPTION
The "DNT" and "Date" header should pass from the HTTP Edge to the Telemetry
decoder. The "Date" header is stored as "clientDate" in decoded messages
for clarity.

"Date" was requested in bug 1144778, "DNT" in bug 1140167.
