### PR TITLE
Get specific records by offset

### DIFF
--- a/bin/build_pipeline_heka.sh
+++ b/bin/build_pipeline_heka.sh
@@ -52,6 +52,7 @@ echo "Installing/updating source files for extra cmds"
 cp -R $BASE/heka/cmd/heka-export ./cmd/
 cp -R $BASE/heka/cmd/heka-s3list ./cmd/
 cp -R $BASE/heka/cmd/heka-s3cat ./cmd/
+cp -R $BASE/heka/cmd/get-clients ./cmd/
 
 echo 'Installing/updating lua filters/modules/decoders'
 rsync -vr $BASE/heka/sandbox/ ./sandbox/lua/

--- a/heka/cmd/get-clients/main.go
+++ b/heka/cmd/get-clients/main.go
@@ -1,0 +1,287 @@
+/***** BEGIN LICENSE BLOCK *****
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+# ***** END LICENSE BLOCK *****/
+
+/*
+
+A command-line utility for getting data by clientid.
+
+*/
+package main
+
+import (
+	"bufio"
+	// "code.google.com/p/gogoprotobuf/proto"
+	// "encoding/json"
+	"flag"
+	"fmt"
+	"github.com/crowdmob/goamz/aws"
+	"github.com/crowdmob/goamz/s3"
+	// "github.com/mozilla-services/data-pipeline/heka/plugins/s3splitfile"
+	"github.com/mozilla-services/heka/message"
+	"io/ioutil"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type MessageLocation struct {
+	Key string
+	// ClientId string
+	Offset uint32
+	Length uint32
+}
+
+type OffsetCache struct {
+	messages map[string][]MessageLocation
+	count    int
+}
+
+func NewOffsetCache() *OffsetCache {
+	return &OffsetCache{map[string][]MessageLocation{}, 0}
+}
+
+func (o *OffsetCache) Add(clientId string, offset MessageLocation) {
+	entries, ok := o.messages[clientId]
+	if !ok {
+		entries = []MessageLocation{}
+	}
+
+	o.messages[clientId] = append(entries, offset)
+	// fmt.Printf("%s now has %d items\n", clientId, len(o.messages[clientId]))
+	o.count++
+}
+
+func (o *OffsetCache) Get(clientId string) []MessageLocation {
+	entries, ok := o.messages[clientId]
+	if !ok {
+		return []MessageLocation{}
+	}
+	return entries
+}
+
+func (o *OffsetCache) Size() int {
+	return o.count
+}
+
+//var offsets = nil
+
+func main() {
+	// flagMatch := flag.String("match", "TRUE", "message_matcher filter expression")
+	// flagFormat := flag.String("format", "txt", "output format [txt|json|heka|count]")
+	flagOutput := flag.String("output", "", "output filename, defaults to stdout")
+	flagOffsets := flag.String("offsets", "", "file containing offset info")
+	flagBucket := flag.String("bucket", "", "S3 Bucket name")
+	flagAWSKey := flag.String("aws-key", "", "AWS Key")
+	flagAWSSecretKey := flag.String("aws-secret-key", "", "AWS Secret Key")
+	flagAWSRegion := flag.String("aws-region", "us-west-2", "AWS Region")
+	flagMaxMessageSize := flag.Uint64("max-message-size", 4*1024*1024, "maximum message size in bytes")
+	flagWorkers := flag.Uint64("workers", 16, "number of parallel workers")
+	flag.Parse()
+
+	if *flagMaxMessageSize < math.MaxUint32 {
+		maxSize := uint32(*flagMaxMessageSize)
+		message.SetMaxMessageSize(maxSize)
+	} else {
+		fmt.Printf("Message size is too large: %d\n", flagMaxMessageSize)
+		os.Exit(8)
+	}
+
+	workers := 1
+	if *flagWorkers < math.MaxUint32 {
+		workers = int(*flagWorkers)
+	} else {
+		fmt.Printf("Too many workers: %d. Are you crazy?\n", flagWorkers)
+		os.Exit(8)
+	}
+
+	var err error
+	// var match *message.MatcherSpecification
+	// if match, err = message.CreateMatcherSpecification(*flagMatch); err != nil {
+	// 	fmt.Printf("Match specification - %s\n", err)
+	// 	os.Exit(2)
+	// }
+
+	var out *os.File
+	if "" == *flagOutput {
+		out = os.Stdout
+	} else {
+		if out, err = os.OpenFile(*flagOutput, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644); err != nil {
+			fmt.Printf("%s\n", err)
+			os.Exit(3)
+		}
+		defer out.Close()
+	}
+
+	// TODO: read offsets file globally
+	offsets, err := readOffsets(*flagOffsets)
+	if err != nil {
+		fmt.Printf("Error reading offsets file: %s\n", err)
+		os.Exit(9)
+	}
+
+	fmt.Printf("Loaded %d offsets\n", offsets.Size())
+
+	auth, err := aws.GetAuth(*flagAWSKey, *flagAWSSecretKey, "", time.Now())
+	if err != nil {
+		fmt.Printf("Authentication error: %s\n", err)
+		os.Exit(4)
+	}
+	region, ok := aws.Regions[*flagAWSRegion]
+	if !ok {
+		fmt.Printf("Parameter 'aws-region' must be a valid AWS Region\n")
+		os.Exit(5)
+	}
+	s := s3.New(auth, region)
+	bucket := s.Bucket(*flagBucket)
+
+	clientIdChannel := make(chan string, 1000)
+	recordChannel := make(chan []byte, 1000)
+	done := make(chan bool)
+	doneSaving := make(chan bool)
+
+	for i := 1; i <= workers; i++ {
+		fmt.Printf("Starting worker %d\n", i)
+		go getClientRecords(bucket, offsets, clientIdChannel, recordChannel, done)
+	}
+	go saveRecords(recordChannel, doneSaving)
+
+	startTime := time.Now().UTC()
+	totalClientIds := 0
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		clientId := scanner.Text()
+
+		fmt.Printf("TODO: get %s\n", clientId)
+		totalClientIds++
+		clientIdChannel <- clientId
+	}
+	close(clientIdChannel)
+
+	<-done
+	close(recordChannel)
+	<-doneSaving
+	duration := time.Now().UTC().Sub(startTime).Seconds()
+	fmt.Printf("All done processing %d clientIds in %.2f seconds\n", totalClientIds, duration)
+}
+
+func makeInt(numstr string) (uint32, error) {
+	i, err := strconv.ParseInt(string(numstr), 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	if i < 0 || i > math.MaxUint32 {
+		return 0, fmt.Errorf("Error parsing %d as uint32")
+	}
+	return uint32(i), nil
+}
+
+func getClientRecords(bucket *s3.Bucket, offsets *OffsetCache, todoChannel <-chan string, recordChannel chan<- []byte, done chan<- bool) {
+	fmt.Printf("One client starting up\n")
+	ok := true
+	for ok {
+		clientId, ok := <-todoChannel
+		if !ok {
+			// Channel is closed
+			done <- true
+			break
+		}
+
+		var headers = map[string][]string{
+			"Range": []string{""},
+		}
+
+		fmt.Printf("Fetching data for %s\n", clientId)
+		for _, o := range offsets.Get(clientId) {
+
+			headers["Range"][0] = fmt.Sprintf("bytes=%d-%d", o.Offset, o.Offset+o.Length)
+			// rangeHeader := fmt.Sprintf("bytes=%d-%d", o.Offset, o.Offset+o.Length)
+			fmt.Printf("Getting %s: %s @ %d+%d // %v\n", clientId, o.Key, o.Offset, o.Length, headers)
+			// record, err := getClientRecord(bucket, o)
+			// if err != nil {
+			// 	fmt.Printf("Error fetching %s @ %d+%d: %s\n", o.Key, o.Offset, o.Length, err)
+			// 	continue
+			// }
+			// fmt.Printf("Successfully fetched %s @ %d+%d: %s\n", o.Key, o.Offset, o.Length, err)
+			// recordChannel <- record
+		}
+		// recordChannel <- []byte(clientId[0:10])
+		// recordChannel <- []byte(clientId[10:20])
+		// // time.Sleep(time.Second * 1)
+		// recordChannel <- []byte(clientId[20:30])
+	}
+}
+
+var headers = map[string][]string{
+	"Range": []string{""},
+}
+
+// headers["Range"] =
+
+func getClientRecord(bucket *s3.Bucket, o MessageLocation) ([]byte, error) {
+	headers["Range"][0] = fmt.Sprintf("bytes=%d-%d", o.Offset, o.Offset+o.Length)
+	resp, err := bucket.GetResponseWithHeaders(o.Key, headers)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if len(body) != int(o.Length) {
+		fmt.Printf("Unexpected body length: %d != %d\n", len(body), o.Length)
+	} else {
+		fmt.Printf("Fetched record of %d.\n", o.Length)
+	}
+	return body, err
+}
+
+func saveRecords(recordChannel <-chan []byte, done chan<- bool) {
+	ok := true
+	for ok {
+		record, ok := <-recordChannel
+		if !ok {
+			// Channel is closed
+			done <- true
+			break
+		}
+
+		fmt.Printf("Saving data for %d\n", len(record))
+	}
+}
+
+func readOffsets(filename string) (*OffsetCache, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	// clientId -> locations
+	var offsets *OffsetCache
+	offsets = NewOffsetCache()
+
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+	for scanner.Scan() {
+		pieces := strings.Split(scanner.Text(), "\t")
+		lineNum++
+		if len(pieces) != 4 {
+			return nil, fmt.Errorf("Error on line %d: invalid line. Expected 4 values, found %d.", lineNum, len(pieces))
+		}
+		o, err := makeInt(pieces[2])
+		if err != nil {
+			return nil, err
+		}
+		l, err := makeInt(pieces[3])
+		if err != nil {
+			return nil, err
+		}
+		offsets.Add(pieces[1], MessageLocation{pieces[0], o, l})
+		// offsets = append(offsets, MessageLocation{pieces[0], pieces[1], o, l})
+	}
+	fmt.Printf("Successfully processed %d offset lines\n", lineNum)
+	return offsets, nil
+}

--- a/heka/cmd/get-clients/main.go
+++ b/heka/cmd/get-clients/main.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"github.com/AdRoll/goamz/aws"
 	"github.com/AdRoll/goamz/s3"
-	// "github.com/mozilla-services/data-pipeline/heka/plugins/s3splitfile"
 	"github.com/mozilla-services/heka/message"
 	"io/ioutil"
 	"math"
@@ -30,8 +29,7 @@ import (
 )
 
 type MessageLocation struct {
-	Key string
-	// ClientId string
+	Key    string
 	Offset uint32
 	Length uint32
 }
@@ -94,6 +92,8 @@ func main() {
 	workers := 1
 	if *flagWorkers < math.MaxUint32 {
 		workers = int(*flagWorkers)
+	} else if *flagWorkers == 0 {
+		fmt.Printf("Cannot run with zero workers. Using 1.\n")
 	} else {
 		fmt.Printf("Too many workers: %d. Are you crazy?\n", flagWorkers)
 		os.Exit(8)
@@ -117,7 +117,6 @@ func main() {
 		defer out.Close()
 	}
 
-	// TODO: read offsets file globally
 	offsets, err := readOffsets(*flagOffsets)
 	if err != nil {
 		fmt.Printf("Error reading offsets file: %s\n", err)

--- a/heka/cmd/heka-s3cat/main.go
+++ b/heka/cmd/heka-s3cat/main.go
@@ -38,6 +38,7 @@ func main() {
 	flagAWSSecretKey := flag.String("aws-secret-key", "", "AWS Secret Key")
 	flagAWSRegion := flag.String("aws-region", "us-west-2", "AWS Region")
 	flagMaxMessageSize := flag.Uint64("max-message-size", 4*1024*1024, "maximum message size in bytes")
+	flagWorkers := flag.Uint64("workers", 16, "number of parallel workers")
 	flag.Parse()
 
 	if !*flagStdin && flag.NArg() < 1 {
@@ -50,6 +51,14 @@ func main() {
 		message.SetMaxMessageSize(maxSize)
 	} else {
 		fmt.Printf("Message size is too large: %d\n", flagMaxMessageSize)
+		os.Exit(8)
+	}
+
+	workers := 1
+	if *flagWorkers < math.MaxUint32 {
+		workers = int(*flagWorkers)
+	} else {
+		fmt.Printf("Too many workers: %d\n", flagWorkers)
 		os.Exit(8)
 	}
 
@@ -84,73 +93,157 @@ func main() {
 	s := s3.New(auth, region)
 	bucket := s.Bucket(*flagBucket)
 
+	filenameChannel := make(chan string, 1000)
+	recordChannel := make(chan s3splitfile.S3Record, 1000)
+	doneChannel := make(chan string, 1000)
+	allDone := make(chan int)
+
+	for i := 1; i <= workers; i++ {
+		go cat(bucket, filenameChannel, recordChannel, doneChannel)
+	}
+	go save(recordChannel, match, *flagFormat, out, allDone)
+
+	startTime := time.Now().UTC()
+	totalFiles := 0
+	pendingFiles := 0
 	if *flagStdin {
 		scanner := bufio.NewScanner(os.Stdin)
 		for scanner.Scan() {
 			filename := scanner.Text()
-			cat(bucket, filename, match, *flagFormat, out)
+			totalFiles++
+			pendingFiles++
+			filenameChannel <- filename
+			if pendingFiles == 1000 {
+				waitFor(doneChannel, 1)
+				pendingFiles--
+			}
 		}
+		close(filenameChannel)
 	} else {
 		for _, filename := range flag.Args() {
-			cat(bucket, filename, match, *flagFormat, out)
+			totalFiles++
+			pendingFiles++
+			filenameChannel <- filename
+			if pendingFiles == 1000 {
+				waitFor(doneChannel, 1)
+				pendingFiles--
+			}
 		}
+		close(filenameChannel)
+	}
+
+	waitFor(doneChannel, pendingFiles)
+	close(recordChannel)
+	bytesRead := <-allDone
+	// All done! Win!
+	duration := time.Now().UTC().Sub(startTime).Seconds()
+	mb := float64(bytesRead) / 1024.0 / 1024.0
+	if duration == 0.0 {
+		duration = 1.0
+	}
+	fmt.Printf("All done processing %d files, %.2fMB in %.2f seconds (%.2fMB/s)\n", totalFiles, mb, duration, (mb / duration))
+}
+
+func cat(bucket *s3.Bucket, filenameChannel <-chan string, recordChannel chan<- s3splitfile.S3Record, doneChannel chan<- string) {
+	ok := true
+	for ok {
+		filename, ok := <-filenameChannel
+		if !ok {
+			// Channel is closed
+			break
+		}
+
+		catOne(bucket, filename, recordChannel)
+		doneChannel <- filename
 	}
 }
 
-func cat(bucket *s3.Bucket, s3Key string, match *message.MatcherSpecification, format string, out *os.File) {
-	var offset, processed, matched int64
-	msg := new(message.Message)
+func catOne(bucket *s3.Bucket, s3Key string, recordChannel chan<- s3splitfile.S3Record) {
+	var processed int64
 
 	for r := range s3splitfile.S3FileIterator(bucket, s3Key) {
-		n := r.BytesRead
-		record := r.Record
+		// record := r.Record
 		err := r.Err
 
 		if err != nil && err != io.EOF {
 			fmt.Printf("Error reading %s: %s\n", s3Key, err)
 		} else {
-			if len(record) > 0 {
+			if len(r.Record) > 0 {
 				processed += 1
-				headerLen := int(record[1]) + message.HEADER_FRAMING_SIZE
-				if err = proto.Unmarshal(record[headerLen:], msg); err != nil {
-					fmt.Printf("Error unmarshalling message %d at offset: %d error: %s\n", processed, offset, err)
-					continue
-				}
-
-				if !match.Match(msg) {
-					continue
-				}
-				matched += 1
-
-				switch format {
-				case "count":
-					// no op
-				case "json":
-					contents, _ := json.Marshal(msg)
-					fmt.Fprintf(out, "%s\n", contents)
-				case "heka":
-					fmt.Fprintf(out, "%s", record)
-				default:
-					fmt.Fprintf(out, "Timestamp: %s\n"+
-						"Type: %s\n"+
-						"Hostname: %s\n"+
-						"Pid: %d\n"+
-						"UUID: %s\n"+
-						"Logger: %s\n"+
-						"Payload: %s\n"+
-						"EnvVersion: %s\n"+
-						"Severity: %d\n"+
-						"Fields: %+v\n\n",
-						time.Unix(0, msg.GetTimestamp()), msg.GetType(),
-						msg.GetHostname(), msg.GetPid(), msg.GetUuidString(),
-						msg.GetLogger(), msg.GetPayload(), msg.GetEnvVersion(),
-						msg.GetSeverity(), msg.Fields)
-				}
+				// headerLen := int(record[1]) + message.HEADER_FRAMING_SIZE
+				recordChannel <- r
 			}
 		}
-
-		offset += int64(n)
 	}
 
-	fmt.Printf("%s: Processed: %d, matched: %d messages\n", s3Key, processed, matched)
+	fmt.Printf("%s: Processed: %d messages\n", s3Key, processed)
+}
+
+func save(recordChannel <-chan s3splitfile.S3Record, match *message.MatcherSpecification, format string, out *os.File, done chan<- int) {
+	processed := 0
+	matched := 0
+	bytes := 0
+	msg := new(message.Message)
+	ok := true
+	for ok {
+		r, ok := <-recordChannel
+		if !ok {
+			// Channel is closed
+			done <- bytes
+			break
+		}
+
+		bytes += len(r.Record)
+
+		processed += 1
+		headerLen := int(r.Record[1]) + message.HEADER_FRAMING_SIZE
+		if err := proto.Unmarshal(r.Record[headerLen:], msg); err != nil {
+			fmt.Printf("Error unmarshalling message %d, error: %s\n", processed, err)
+			continue
+		}
+
+		if !match.Match(msg) {
+			continue
+		}
+
+		matched += 1
+
+		// fmt.Printf("Saving data for %s\n", msg.GetPayload())
+		switch format {
+		case "count":
+			// no op
+		case "json":
+			contents, _ := json.Marshal(msg)
+			fmt.Fprintf(out, "%s\n", contents)
+		case "heka":
+			fmt.Fprintf(out, "%s", r.Record)
+		default:
+			fmt.Fprintf(out, "Timestamp: %s\n"+
+				"Type: %s\n"+
+				"Hostname: %s\n"+
+				"Pid: %d\n"+
+				"UUID: %s\n"+
+				"Logger: %s\n"+
+				"Payload: %s\n"+
+				"EnvVersion: %s\n"+
+				"Severity: %d\n"+
+				"Fields: %+v\n\n",
+				time.Unix(0, msg.GetTimestamp()), msg.GetType(),
+				msg.GetHostname(), msg.GetPid(), msg.GetUuidString(),
+				msg.GetLogger(), msg.GetPayload(), msg.GetEnvVersion(),
+				msg.GetSeverity(), msg.Fields)
+		}
+	}
+	fmt.Printf("Processed: %d, matched: %d messages (%.2f MB)\n", processed, matched, (float64(bytes) / 1024.0 / 1024.0))
+}
+
+func waitFor(completedChannel <-chan string, count int) {
+	var completed string
+	// Now wait for all the clients to complete:
+	for i := 1; i <= count; i++ {
+		//fmt.Printf("Waiting for client %d of %d...\n", i, count)
+		completed = <-completedChannel
+		fmt.Printf("Completed: %s\n", completed)
+		//fmt.Printf("Finished reading %s, %d of %d completed.\n", completed, i, count)
+	}
 }

--- a/heka/cmd/heka-s3cat/main.go
+++ b/heka/cmd/heka-s3cat/main.go
@@ -218,6 +218,7 @@ func save(recordChannel <-chan s3splitfile.S3Record, match *message.MatcherSpeci
 		case "heka":
 			fmt.Fprintf(out, "%s", r.Record)
 		case "offsets":
+			// Use offsets mode for indexing the S3 files by clientId
 			clientId, ok := msg.GetFieldValue("clientId")
 			if ok {
 				fmt.Fprintf(out, "%s\t%s\t%d\t%d\n", r.Key, clientId, (r.Offset + uint64(headerLen)), (len(r.Record) - headerLen))

--- a/heka/cmd/heka-s3cat/main.go
+++ b/heka/cmd/heka-s3cat/main.go
@@ -219,7 +219,7 @@ func save(recordChannel <-chan s3splitfile.S3Record, match *message.MatcherSpeci
 		case "offsets":
 			// Use offsets mode for indexing the S3 files by clientId
 			clientId, ok := msg.GetFieldValue("clientId")
-			recordLength := len(r.Record) - headerLen)
+			recordLength := len(r.Record) - headerLen
 			if ok {
 				fmt.Fprintf(out, "%s\t%s\t%d\t%d\n", r.Key, clientId, (r.Offset + uint64(headerLen)), recordLength)
 			} else {

--- a/heka/cmd/heka-s3cat/main.go
+++ b/heka/cmd/heka-s3cat/main.go
@@ -217,6 +217,13 @@ func save(recordChannel <-chan s3splitfile.S3Record, match *message.MatcherSpeci
 			fmt.Fprintf(out, "%s\n", contents)
 		case "heka":
 			fmt.Fprintf(out, "%s", r.Record)
+		case "offsets":
+			clientId, ok := msg.GetFieldValue("clientId")
+			if ok {
+				fmt.Fprintf(out, "%s\t%s\t%d\t%d\n", r.Key, clientId, (r.Offset + uint64(headerLen)), (len(r.Record) - headerLen))
+			} else {
+				fmt.Printf("Missing client id in record %d\n", processed)
+			}
 		default:
 			fmt.Fprintf(out, "Timestamp: %s\n"+
 				"Type: %s\n"+

--- a/heka/patches/0003-Add-more-cmds.patch
+++ b/heka/patches/0003-Add-more-cmds.patch
@@ -11,16 +11,17 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index a5cdd21..705d223 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -37,6 +37,8 @@ set(INJECT_EXE "${PROJECT_PATH}/bin/heka-inject${CMAKE_EXECUTABLE_SUFFIX}")
+@@ -37,6 +37,9 @@ set(INJECT_EXE "${PROJECT_PATH}/bin/heka-inject${CMAKE_EXECUTABLE_SUFFIX}")
  set(LOGSTREAMER_EXE "${PROJECT_PATH}/bin/heka-logstreamer${CMAKE_EXECUTABLE_SUFFIX}")
  set(HEKA_CAT_EXE "${PROJECT_PATH}/bin/heka-cat${CMAKE_EXECUTABLE_SUFFIX}")
  set(HEKA_EXPORT_EXE "${PROJECT_PATH}/bin/heka-export${CMAKE_EXECUTABLE_SUFFIX}")
 +set(HEKA_S3LIST_EXE "${PROJECT_PATH}/bin/heka-s3list${CMAKE_EXECUTABLE_SUFFIX}")
 +set(HEKA_S3CAT_EXE "${PROJECT_PATH}/bin/heka-s3cat${CMAKE_EXECUTABLE_SUFFIX}")
++set(GET_CLIENTS_EXE "${PROJECT_PATH}/bin/get-clients${CMAKE_EXECUTABLE_SUFFIX}")
  
  option(INCLUDE_SANDBOX "Include Lua sandbox" on)
  option(INCLUDE_MOZSVC "Include the Mozilla services plugins" on)
-@@ -225,6 +227,20 @@ WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+@@ -225,6 +228,27 @@ WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
  
  install(PROGRAMS "${HEKA_EXPORT_EXE}" DESTINATION bin)
  
@@ -37,6 +38,13 @@ index a5cdd21..705d223 100644
 +WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 +
 +install(PROGRAMS "${HEKA_S3CAT_EXE}" DESTINATION bin)
++
++add_custom_target(get-clients ALL
++${GO_EXECUTABLE} install ${LDFLAGS} github.com/mozilla-services/heka/cmd/get-clients
++DEPENDS hekad
++WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
++
++install(PROGRAMS "${GET_CLIENTS_EXE}" DESTINATION bin)
 +
  add_custom_target(sbmgr ALL
  ${GO_EXECUTABLE} install ${LDFLAGS} github.com/mozilla-services/heka/cmd/heka-sbmgr


### PR DESCRIPTION
This PR includes two main changes:
1. Parallelize heka-s3cat to improve throughput.
2. Add a `get-clients` cmd which can fetch specific records within S3 files using a local index.  This is intended to be used to fetch records for a particular `clientId` for telemetry data.

It also adds an "offsets" output format to `heka-s3cat` for generating the index expected by `get-clients`.
