### PR TITLE
Parallelize heka-s3cat

### DIFF
--- a/heka/cmd/heka-s3cat/main.go
+++ b/heka/cmd/heka-s3cat/main.go
@@ -38,6 +38,7 @@ func main() {
 	flagAWSSecretKey := flag.String("aws-secret-key", "", "AWS Secret Key")
 	flagAWSRegion := flag.String("aws-region", "us-west-2", "AWS Region")
 	flagMaxMessageSize := flag.Uint64("max-message-size", 4*1024*1024, "maximum message size in bytes")
+	flagWorkers := flag.Uint64("workers", 16, "number of parallel workers")
 	flag.Parse()
 
 	if !*flagStdin && flag.NArg() < 1 {
@@ -50,6 +51,16 @@ func main() {
 		message.SetMaxMessageSize(maxSize)
 	} else {
 		fmt.Printf("Message size is too large: %d\n", flagMaxMessageSize)
+		os.Exit(8)
+	}
+
+	workers := 1
+	if *flagWorkers == 0 {
+		fmt.Printf("Cannot run with zero workers. Using 1.\n")
+	} else if *flagWorkers < math.MaxUint32 {
+		workers = int(*flagWorkers)
+	} else {
+		fmt.Printf("Too many workers: %d. Use a reasonable value (up to a few hundred).\n", flagWorkers)
 		os.Exit(8)
 	}
 
@@ -84,73 +95,166 @@ func main() {
 	s := s3.New(auth, region)
 	bucket := s.Bucket(*flagBucket)
 
+	filenameChannel := make(chan string, 1000)
+	recordChannel := make(chan s3splitfile.S3Record, 1000)
+	doneChannel := make(chan string, 1000)
+	allDone := make(chan int)
+
+	for i := 1; i <= workers; i++ {
+		go cat(bucket, filenameChannel, recordChannel, doneChannel)
+	}
+	go save(recordChannel, match, *flagFormat, out, allDone)
+
+	startTime := time.Now().UTC()
+	totalFiles := 0
+	pendingFiles := 0
 	if *flagStdin {
 		scanner := bufio.NewScanner(os.Stdin)
 		for scanner.Scan() {
 			filename := scanner.Text()
-			cat(bucket, filename, match, *flagFormat, out)
+			totalFiles++
+			pendingFiles++
+			filenameChannel <- filename
+			if pendingFiles >= 1000 {
+				waitFor(doneChannel, 1)
+				pendingFiles--
+			}
 		}
+		close(filenameChannel)
 	} else {
 		for _, filename := range flag.Args() {
-			cat(bucket, filename, match, *flagFormat, out)
+			totalFiles++
+			pendingFiles++
+			filenameChannel <- filename
+			if pendingFiles >= 1000 {
+				waitFor(doneChannel, 1)
+				pendingFiles--
+			}
 		}
+		close(filenameChannel)
+	}
+
+	fmt.Printf("Waiting for last %d files\n", pendingFiles)
+	waitFor(doneChannel, pendingFiles)
+	close(recordChannel)
+	bytesRead := <-allDone
+	// All done! Win!
+	duration := time.Now().UTC().Sub(startTime).Seconds()
+	mb := float64(bytesRead) / 1024.0 / 1024.0
+	if duration == 0.0 {
+		duration = 1.0
+	}
+	fmt.Printf("All done processing %d files, %.2fMB in %.2f seconds (%.2fMB/s)\n", totalFiles, mb, duration, (mb / duration))
+}
+
+// Cat all filenames read from filenameChannel
+func cat(bucket *s3.Bucket, filenameChannel <-chan string, recordChannel chan<- s3splitfile.S3Record, doneChannel chan<- string) {
+	ok := true
+	for ok {
+		filename, ok := <-filenameChannel
+		if !ok {
+			// Channel is closed
+			break
+		}
+
+		catOne(bucket, filename, recordChannel)
+		doneChannel <- filename
 	}
 }
 
-func cat(bucket *s3.Bucket, s3Key string, match *message.MatcherSpecification, format string, out *os.File) {
-	var offset, processed, matched int64
-	msg := new(message.Message)
+// Cat the records from a single S3 key
+func catOne(bucket *s3.Bucket, s3Key string, recordChannel chan<- s3splitfile.S3Record) {
+	var processed int64
 
 	for r := range s3splitfile.S3FileIterator(bucket, s3Key) {
-		n := r.BytesRead
-		record := r.Record
 		err := r.Err
 
 		if err != nil && err != io.EOF {
 			fmt.Printf("Error reading %s: %s\n", s3Key, err)
 		} else {
-			if len(record) > 0 {
+			if len(r.Record) > 0 {
 				processed += 1
-				headerLen := int(record[1]) + message.HEADER_FRAMING_SIZE
-				if err = proto.Unmarshal(record[headerLen:], msg); err != nil {
-					fmt.Printf("Error unmarshalling message %d at offset: %d error: %s\n", processed, offset, err)
-					continue
-				}
-
-				if !match.Match(msg) {
-					continue
-				}
-				matched += 1
-
-				switch format {
-				case "count":
-					// no op
-				case "json":
-					contents, _ := json.Marshal(msg)
-					fmt.Fprintf(out, "%s\n", contents)
-				case "heka":
-					fmt.Fprintf(out, "%s", record)
-				default:
-					fmt.Fprintf(out, "Timestamp: %s\n"+
-						"Type: %s\n"+
-						"Hostname: %s\n"+
-						"Pid: %d\n"+
-						"UUID: %s\n"+
-						"Logger: %s\n"+
-						"Payload: %s\n"+
-						"EnvVersion: %s\n"+
-						"Severity: %d\n"+
-						"Fields: %+v\n\n",
-						time.Unix(0, msg.GetTimestamp()), msg.GetType(),
-						msg.GetHostname(), msg.GetPid(), msg.GetUuidString(),
-						msg.GetLogger(), msg.GetPayload(), msg.GetEnvVersion(),
-						msg.GetSeverity(), msg.Fields)
-				}
+				recordChannel <- r
 			}
 		}
-
-		offset += int64(n)
 	}
 
-	fmt.Printf("%s: Processed: %d, matched: %d messages\n", s3Key, processed, matched)
+	fmt.Printf("%s: Processed: %d messages\n", s3Key, processed)
+}
+
+// Save matching client records locally to the given output file in the given
+// format.
+func save(recordChannel <-chan s3splitfile.S3Record, match *message.MatcherSpecification, format string, out *os.File, done chan<- int) {
+	processed := 0
+	matched := 0
+	bytes := 0
+	msg := new(message.Message)
+	ok := true
+	for ok {
+		r, ok := <-recordChannel
+		if !ok {
+			// Channel is closed
+			done <- bytes
+			break
+		}
+
+		bytes += len(r.Record)
+
+		processed += 1
+		headerLen := int(r.Record[1]) + message.HEADER_FRAMING_SIZE
+		if err := proto.Unmarshal(r.Record[headerLen:], msg); err != nil {
+			fmt.Printf("Error unmarshalling message %d, error: %s\n", processed, err)
+			continue
+		}
+
+		if !match.Match(msg) {
+			continue
+		}
+
+		matched += 1
+
+		switch format {
+		case "count":
+			// no op
+		case "json":
+			contents, _ := json.Marshal(msg)
+			fmt.Fprintf(out, "%s\n", contents)
+		case "heka":
+			fmt.Fprintf(out, "%s", r.Record)
+		case "offsets":
+			// Use offsets mode for indexing the S3 files by clientId
+			clientId, ok := msg.GetFieldValue("clientId")
+			recordLength := len(r.Record) - headerLen
+			if ok {
+				fmt.Fprintf(out, "%s\t%s\t%d\t%d\n", r.Key, clientId, (r.Offset + uint64(headerLen)), recordLength)
+			} else {
+				fmt.Printf("Missing client id in %s @ %d+%d\n", r.Key, r.Offset, recordLength)
+			}
+		default:
+			fmt.Fprintf(out, "Timestamp: %s\n"+
+				"Type: %s\n"+
+				"Hostname: %s\n"+
+				"Pid: %d\n"+
+				"UUID: %s\n"+
+				"Logger: %s\n"+
+				"Payload: %s\n"+
+				"EnvVersion: %s\n"+
+				"Severity: %d\n"+
+				"Fields: %+v\n\n",
+				time.Unix(0, msg.GetTimestamp()), msg.GetType(),
+				msg.GetHostname(), msg.GetPid(), msg.GetUuidString(),
+				msg.GetLogger(), msg.GetPayload(), msg.GetEnvVersion(),
+				msg.GetSeverity(), msg.Fields)
+		}
+	}
+	fmt.Printf("Processed: %d, matched: %d messages (%.2f MB)\n", processed, matched, (float64(bytes) / 1024.0 / 1024.0))
+}
+
+func waitFor(completedChannel <-chan string, count int) {
+	var completed string
+	// Now wait for all the clients to complete:
+	for i := 1; i <= count; i++ {
+		completed = <-completedChannel
+		fmt.Printf("Completed: %s\n", completed)
+	}
 }

--- a/heka/cmd/heka-s3cat/main.go
+++ b/heka/cmd/heka-s3cat/main.go
@@ -57,7 +57,7 @@ func main() {
 	workers := 1
 	if *flagWorkers == 0 {
 		fmt.Printf("Cannot run with zero workers. Using 1.\n")
-	} else if *flagWorkers < math.MaxUint32 {
+	} else if *flagWorkers < 2000 {
 		workers = int(*flagWorkers)
 	} else {
 		fmt.Printf("Too many workers: %d. Use a reasonable value (up to a few hundred).\n", flagWorkers)


### PR DESCRIPTION
Fetch multiple files at the same time to improve throughput, and add an "offsets" mode for indexing the records within the S3 data files by client id.
