### PR TITLE
Add a snappy encoder / decoder.

### DIFF
--- a/bin/build_pipeline_heka.sh
+++ b/bin/build_pipeline_heka.sh
@@ -46,6 +46,7 @@ if [ ! -f "patches_applied" ]; then
 
     echo "Adding external plugin for s3splitfile output"
     echo "add_external_plugin(git https://github.com/mozilla-services/data-pipeline/s3splitfile :local)" >> cmake/plugin_loader.cmake
+    echo "add_external_plugin(git https://github.com/mozilla-services/data-pipeline/snap :local)" >> cmake/plugin_loader.cmake
 
     echo "Adding external plugin for golang-lru output"
     echo "add_external_plugin(git https://github.com/mreid-moz/golang-lru acc5bd27065280640fa0a79a973076c6abaccec8)" >> cmake/plugin_loader.cmake

--- a/heka/plugins/snap/snappy_decoder.go
+++ b/heka/plugins/snap/snappy_decoder.go
@@ -1,0 +1,39 @@
+/***** BEGIN LICENSE BLOCK *****
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+# ***** END LICENSE BLOCK *****/
+
+package snap
+
+import (
+	"code.google.com/p/snappy-go/snappy"
+	. "github.com/mozilla-services/heka/pipeline"
+)
+
+// SnappyDecoder decompresses snappy-compressed Message bytes.
+type SnappyDecoder struct {
+}
+
+func (re *SnappyDecoder) Init(config interface{}) (err error) {
+	return
+}
+
+func (re *SnappyDecoder) Decode(pack *PipelinePack) (packs []*PipelinePack, err error) {
+	output, decodeErr := snappy.Decode(nil, pack.MsgBytes)
+
+	packs = []*PipelinePack{pack}
+	if decodeErr == nil {
+		// Replace bytes with decoded data
+		pack.MsgBytes = output
+	}
+	// If there is an error decoding snappy, maybe it wasn't compressed. We'll
+	// return the original data and try to proceed.
+	return
+}
+
+func init() {
+	RegisterPlugin("SnappyDecoder", func() interface{} {
+		return new(SnappyDecoder)
+	})
+}

--- a/heka/plugins/snap/snappy_encoder.go
+++ b/heka/plugins/snap/snappy_encoder.go
@@ -1,0 +1,32 @@
+/***** BEGIN LICENSE BLOCK *****
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+# ***** END LICENSE BLOCK *****/
+
+package snap
+
+import (
+	"code.google.com/p/snappy-go/snappy"
+	. "github.com/mozilla-services/heka/pipeline"
+)
+
+// SnappyEncoder compresses the Message bytes using snappy compression. Each
+// message is compressed separately.
+type SnappyEncoder struct {
+}
+
+func (re *SnappyEncoder) Init(config interface{}) (err error) {
+	return
+}
+
+func (re *SnappyEncoder) Encode(pack *PipelinePack) (output []byte, err error) {
+	output, err = snappy.Encode(nil, pack.MsgBytes)
+	return
+}
+
+func init() {
+	RegisterPlugin("SnappyEncoder", func() interface{} {
+		return new(SnappyEncoder)
+	})
+}


### PR DESCRIPTION
We ignore decode errors, as this lets you use the decoder on
both compressed and plain data.
