### PR TITLE
Add a filter to count submissions by channel.

### DIFF
--- a/heka/sandbox/filters/count_by_normalized_channel.lua
+++ b/heka/sandbox/filters/count_by_normalized_channel.lua
@@ -24,10 +24,11 @@ fx = require "fx"
 local rows = read_config("rows") or 1440
 local sec_per_row = read_config("sec_per_row") or 60
 
-local num_channels = fx.get_channel_count()
-local channel_counter = circular_buffer.new(rows, num_channels, sec_per_row, true)
-for i=1,num_channels do
-    channel_counter:set_header(i, fx.get_channel_name(i))
+local nchannels = fx.get_channel_count()
+local channel_counter = circular_buffer.new(rows, nchannels, sec_per_row, true)
+for i=1,nchannels do
+    -- Circular buffer columns are one-based, channel ids are zero-based.
+    channel_counter:set_header(i, fx.get_channel_name(i - 1))
 end
 
 function process_message()
@@ -37,8 +38,8 @@ function process_message()
     local normalized = fx.normalize_channel(channel)
 
     -- Need to add one to account for "Other" (which comes back as zero)
-    local channel_id = fx.get_channel_id(normalized) + 1
-    channel_counter:add(ts, channel_id, 1)
+    local column_id = fx.get_channel_id(normalized) + 1
+    channel_counter:add(ts, column_id, 1)
     return 0
 end
 

--- a/heka/sandbox/filters/count_by_normalized_channel.lua
+++ b/heka/sandbox/filters/count_by_normalized_channel.lua
@@ -1,0 +1,46 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+--[[
+Request Counts by Normalized Channel
+
+*Example Heka Configuration*
+
+.. code-block:: ini
+
+    [CountByNormalizedChannel]
+    type = "SandboxFilter"
+    filename = "lua_filters/count_by_normalized_channel.lua"
+    message_matcher = "Type == 'telemetry'"
+    ticker_interval = 30
+    preserve_data = true
+
+--]]
+
+require "circular_buffer"
+fx = require "fx"
+
+local rows = read_config("rows") or 1440
+local sec_per_row = read_config("sec_per_row") or 60
+
+local num_channels = fx.get_channel_count()
+local channel_counter = circular_buffer.new(rows, num_channels, sec_per_row, true)
+for i=1,num_channels do
+    channel_counter:set_header(i, fx.get_channel_name(i))
+end
+
+function process_message()
+    local ts = read_message("Timestamp")
+    if not all:add(ts, REQUESTS, 1) then return 0 end -- outside the buffer
+
+    local channel = read_message("Fields[appUpdateChannel]") or "Other"
+    local normalized = fx.normalize_channel(channel)
+    local channel_id = fx.get_channel_id(normalized)
+    c:add(ts, channel_id, 1)
+    return 0
+end
+
+function timer_event(ns)
+    inject_payload("cbuf", "Counts by Normalized Channel", channel_counter)
+end

--- a/heka/sandbox/filters/count_by_normalized_channel.lua
+++ b/heka/sandbox/filters/count_by_normalized_channel.lua
@@ -32,12 +32,13 @@ end
 
 function process_message()
     local ts = read_message("Timestamp")
-    if not all:add(ts, REQUESTS, 1) then return 0 end -- outside the buffer
 
     local channel = read_message("Fields[appUpdateChannel]") or "Other"
     local normalized = fx.normalize_channel(channel)
-    local channel_id = fx.get_channel_id(normalized)
-    c:add(ts, channel_id, 1)
+
+    -- Need to add one to account for "Other" (which comes back as zero)
+    local channel_id = fx.get_channel_id(normalized) + 1
+    channel_counter:add(ts, channel_id, 1)
     return 0
 end
 

--- a/heka/sandbox/filters/count_by_normalized_channel.lua
+++ b/heka/sandbox/filters/count_by_normalized_channel.lua
@@ -12,7 +12,7 @@ Request Counts by Normalized Channel
     [CountByNormalizedChannel]
     type = "SandboxFilter"
     filename = "lua_filters/count_by_normalized_channel.lua"
-    message_matcher = "Type == 'telemetry'"
+    message_matcher = "Type == 'telemetry' && Fields[docType] == 'main'"
     ticker_interval = 30
     preserve_data = true
 
@@ -33,9 +33,7 @@ end
 
 function process_message()
     local ts = read_message("Timestamp")
-
-    local channel = read_message("Fields[appUpdateChannel]") or "Other"
-    local normalized = fx.normalize_channel(channel)
+    local normalized = fx.normalize_channel(read_message("Fields[appUpdateChannel]"))
 
     -- Need to add one to account for "Other" (which comes back as zero)
     local column_id = fx.get_channel_id(normalized) + 1


### PR DESCRIPTION
The sandboxed version keeps getting killed because there are too many variants on the channel names (more than ten).  This uses the shared fx module to normalize the channel name before counting.
