### PR TITLE
Use correct fields for crash pings.

### DIFF
--- a/heka/sandbox/filters/firefox_monthly_dashboard.lua
+++ b/heka/sandbox/filters/firefox_monthly_dashboard.lua
@@ -91,13 +91,20 @@ local function update_month(ts, cid, day_changed)
         current_month = month
     end
 
-    local country = fx.get_country_id(read_message("Fields[country]"))
-    local channel = fx.get_channel_id(read_message("Fields[channel]"))
-    local _os     = fx.get_os_id(read_message("Fields[os]"))
+    local msgType = read_message("Type")
+    local _os = fx.get_os_id(read_message("Fields[os]"))
+    local country, channel
+    if msgType == "executive_summary" then
+        country = fx.get_country_id(read_message("Fields[country]"))
+        channel = fx.get_channel_id(read_message("Fields[channel]"))
+    else
+        country = fx.get_country_id(read_message("Fields[geoCountry]"))
+        channel = fx.get_channel_id(read_message("Fields[appUpdateChannel]"))
+    end
 
     local r = get_row(ts, month, country, channel, _os)
     if r then
-        if read_message("Type") == "executive_summary" then
+        if msgType == "executive_summary" then
             local dflt = fx.get_boolean_value(read_message("Fields[default]"))
             fx_cids:add(cid, country, channel, _os, 0, dflt)
             r[3]  = r[3]  + (tonumber(read_message("Fields[hours]")) or 0)

--- a/heka/sandbox/filters/firefox_weekly_dashboard.lua
+++ b/heka/sandbox/filters/firefox_weekly_dashboard.lua
@@ -82,14 +82,20 @@ local function update_week(ts, cid, day)
     elseif delta < 0 then
         error("data is in the past, this report doesn't back fill")
     end
-
-    local country = fx.get_country_id(read_message("Fields[country]"))
-    local channel = fx.get_channel_id(read_message("Fields[channel]"))
-    local _os     = fx.get_os_id(read_message("Fields[os]"))
+    local msgType = read_message("Type")
+    local _os = fx.get_os_id(read_message("Fields[os]"))
+    local country, channel
+    if msgType == "executive_summary" then
+        country = fx.get_country_id(read_message("Fields[country]"))
+        channel = fx.get_channel_id(read_message("Fields[channel]"))
+    else
+        country = fx.get_country_id(read_message("Fields[geoCountry]"))
+        channel = fx.get_channel_id(read_message("Fields[appUpdateChannel]"))
+    end
 
     local r = get_row(week, country, channel, _os)
     if r then
-        if read_message("Type") == "executive_summary" then
+        if msgType == "executive_summary" then
             local dflt = fx.get_boolean_value(read_message("Fields[default]"))
             fx_cids:add(cid, country, channel, _os, (day + DAY_OFFSET) % 7, dflt)
             r[3]  = r[3]  + (tonumber(read_message("Fields[hours]")) or 0)


### PR DESCRIPTION
Crash pings use "geoCountry" and "appUpdateChannel", while executive
summary pings use "country" and "channel".
