### PR TITLE
Update OS Bucketing, normalize crash data.

### DIFF
--- a/heka/sandbox/filters/firefox_monthly_dashboard.lua
+++ b/heka/sandbox/filters/firefox_monthly_dashboard.lua
@@ -92,7 +92,6 @@ local function update_month(ts, cid, day_changed)
     end
 
     local msgType = read_message("Type")
-    local _os = fx.get_os_id(read_message("Fields[os]"))
     local country, channel, _os
     if msgType == "executive_summary" then
         country = fx.get_country_id(read_message("Fields[country]"))

--- a/heka/sandbox/filters/firefox_monthly_dashboard.lua
+++ b/heka/sandbox/filters/firefox_monthly_dashboard.lua
@@ -93,13 +93,15 @@ local function update_month(ts, cid, day_changed)
 
     local msgType = read_message("Type")
     local _os = fx.get_os_id(read_message("Fields[os]"))
-    local country, channel
+    local country, channel, _os
     if msgType == "executive_summary" then
         country = fx.get_country_id(read_message("Fields[country]"))
         channel = fx.get_channel_id(read_message("Fields[channel]"))
+        _os     = fx.get_os_id(read_message("Fields[os]"))
     else
         country = fx.get_country_id(read_message("Fields[geoCountry]"))
-        channel = fx.get_channel_id(read_message("Fields[appUpdateChannel]"))
+        channel = fx.get_channel_id(fx.normalize_channel(read_message("Fields[appUpdateChannel]")))
+        _os     = fx.get_os_id(fx.normalize_os(read_message("Fields[os]")))
     end
 
     local r = get_row(ts, month, country, channel, _os)

--- a/heka/sandbox/filters/firefox_weekly_dashboard.lua
+++ b/heka/sandbox/filters/firefox_weekly_dashboard.lua
@@ -83,14 +83,15 @@ local function update_week(ts, cid, day)
         error("data is in the past, this report doesn't back fill")
     end
     local msgType = read_message("Type")
-    local _os = fx.get_os_id(read_message("Fields[os]"))
-    local country, channel
+    local country, channel, _os
     if msgType == "executive_summary" then
         country = fx.get_country_id(read_message("Fields[country]"))
         channel = fx.get_channel_id(read_message("Fields[channel]"))
+        _os     = fx.get_os_id(read_message("Fields[os]"))
     else
         country = fx.get_country_id(read_message("Fields[geoCountry]"))
-        channel = fx.get_channel_id(read_message("Fields[appUpdateChannel]"))
+        channel = fx.get_channel_id(fx.normalize_channel(read_message("Fields[appUpdateChannel]")))
+        _os     = fx.get_os_id(fx.normalize_os(read_message("Fields[os]")))
     end
 
     local r = get_row(week, country, channel, _os)

--- a/heka/sandbox/modules/fx.lua
+++ b/heka/sandbox/modules/fx.lua
@@ -27,7 +27,7 @@ local function anywhere (p)
 end
 
 local normalize_os_grammar =
-(l.P"Windows" + "WINNT" + "Windows_NT") / "Windows" +
+(l.P"Windows" + "WINNT") / "Windows" +
 l.P"Darwin" / "Mac" +
 (anywhere"Linux" + anywhere"BSD" + anywhere"SunOS") / "Linux" +
 l.Cc"Other"

--- a/heka/sandbox/modules/fx.lua
+++ b/heka/sandbox/modules/fx.lua
@@ -27,7 +27,7 @@ local function anywhere (p)
 end
 
 local normalize_os_grammar =
-(l.P"Windows" + "WINNT") / "Windows" +
+(l.P"Windows" + "WINNT" + "Windows_NT") / "Windows" +
 l.P"Darwin" / "Mac" +
 (anywhere"Linux" + anywhere"BSD" + anywhere"SunOS") / "Linux" +
 l.Cc"Other"


### PR DESCRIPTION
Crash data uses a value of "Windows_NT" for the "os" field. Also,
channel and os are already normalized in the executive summary, but
not in crashes, so we need to normalize before getting ids.
