### PR TITLE
Don't finalize the executive reports on exit

### DIFF
--- a/heka/sandbox/filters/firefox_monthly_dashboard.lua
+++ b/heka/sandbox/filters/firefox_monthly_dashboard.lua
@@ -133,7 +133,6 @@ end
 function timer_event(ns)
     if current_month == -1 then return end
 
-    fx_cids:report(months[current_month])
     add_to_payload("geo,channel,os,date,actives,hours,inactives,new_records,five_of_seven,total_records,crashes,default,google,bing,yahoo,other\n")
     local country, channel, _os
     for i,t in ipairs(months) do

--- a/heka/sandbox/filters/firefox_weekly_dashboard.lua
+++ b/heka/sandbox/filters/firefox_weekly_dashboard.lua
@@ -120,7 +120,6 @@ end
 function timer_event(ns)
     if current_week == -1 then return end
 
-    fx_cids:report(weeks[current_week % WEEKS + 1])
     add_to_payload("geo,channel,os,date,actives,hours,inactives,new_records,five_of_seven,total_records,crashes,default,google,bing,yahoo,other\n")
     local country, channel, _os
     for i,t in ipairs(weeks) do


### PR DESCRIPTION
When we run in incremental mode (one day at a time) we cannot
finalize the week/month on each exit. This was used for debug and
when running a full report to produce a partial last week/month set
of results.
