### PR TITLE
Add os, sessionLength, and architecture to elasticsearch

### DIFF
--- a/heka/sandbox/encoders/es_fields.lua
+++ b/heka/sandbox/encoders/es_fields.lua
@@ -96,6 +96,7 @@ local info_fields = {
   , "sessionStartDate"
   , "subsessionStartDate"
   , "subsessionLength"
+  , "sessionLength"
 }
 
 local environment_fields = {
@@ -167,6 +168,11 @@ function process_message()
                 tbl[k] = info[k]
             end
         end
+    end
+
+    local ok, payload = pcall(cjson.decode, read_message("Payload"))
+    if ok and payload.application.architecture then
+      tbl.architecture = payload.application.architecture
     end
 
     if tbl.creationTimestamp then

--- a/heka/sandbox/encoders/es_fields.lua
+++ b/heka/sandbox/encoders/es_fields.lua
@@ -171,8 +171,8 @@ function process_message()
     end
 
     local ok, payload = pcall(cjson.decode, read_message("Payload"))
-    if ok and payload.application.architecture then
-      tbl.architecture = payload.application.architecture
+    if ok and type(payload.application) == "table" and payload.application.architecture then
+        tbl.architecture = payload.application.architecture
     end
 
     if tbl.creationTimestamp then


### PR DESCRIPTION
`os` is a top-level field and the config for that is in puppet.
