### PR TITLE
[do not merge] Make a branch that can build kafka consumer group code

### DIFF
--- a/bin/build_pipeline_heka.sh
+++ b/bin/build_pipeline_heka.sh
@@ -27,13 +27,13 @@ fi
 cd build
 if [ ! -d heka ]; then
     # Fetch a fresh heka clone
-    git clone https://github.com/mozilla-services/heka
+    git clone https://github.com/whd/heka
 fi
 
 cd heka
 # pin the Heka version
 git fetch
-git checkout 6094d1db354301813384273e3e09fb33df8137c2
+git checkout 015002ba761aea4836255478b36b4356da0ea77a
 
 if [ ! -f "patches_applied" ]; then
     touch patches_applied
@@ -50,7 +50,6 @@ if [ ! -f "patches_applied" ]; then
 
     echo "Adding external plugin for golang-lru output"
     echo "add_external_plugin(git https://github.com/mreid-moz/golang-lru acc5bd27065280640fa0a79a973076c6abaccec8)" >> cmake/plugin_loader.cmake
-    echo "add_external_plugin(git https://github.com/golang/snappy master)" >> cmake/plugin_loader.cmake
 fi
 
 # TODO: do this using cmake externals instead of shell-fu.
@@ -147,6 +146,6 @@ Darwin)
 esac
 if hash rpmrebuild 2>/dev/null; then
     echo "Rebuilding RPM with date iteration and svc suffix"
-    rpmrebuild -d . --release=0.$(date +%Y%m%d)svc -p -n heka-*-linux-amd64.rpm
+    rpmrebuild -d . --release=0.$(date +%Y%m%d)cgsvc -p -n heka-*-linux-amd64.rpm
 fi
 popd

--- a/heka/cmd/heka-s3cat/main.go
+++ b/heka/cmd/heka-s3cat/main.go
@@ -14,12 +14,12 @@ package main
 
 import (
 	"bufio"
-	"code.google.com/p/gogoprotobuf/proto"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"github.com/AdRoll/goamz/aws"
 	"github.com/AdRoll/goamz/s3"
+	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/mozilla-services/data-pipeline/s3splitfile"
 	"github.com/mozilla-services/heka/message"

--- a/heka/plugins/s3splitfile/s3splitfile_output.go
+++ b/heka/plugins/s3splitfile/s3splitfile_output.go
@@ -452,7 +452,7 @@ func (o *S3SplitFileOutput) receiver(or OutputRunner, wg *sync.WaitGroup) {
 			}
 			// else the encoder did not emit a message.
 
-			pack.Recycle()
+			pack.Recycle(nil)
 		case <-o.timerChan:
 			if e = o.rotateFiles(); e != nil {
 				or.LogError(fmt.Errorf("Error rotating files by time: %s", e))


### PR DESCRIPTION
There is a long story here involving the various heka, data-pipeline, snappy, and sarama repositories, but the short version is that in order to build this consumer group code without going into dependency hell I had to remove the other kafka plugins from the heka branch referenced in this PR. The actual code is here: https://github.com/mozilla-services/heka/compare/dev...whd:kafka_consumer_group.

This is being tested in stage, but preliminary tests look good: multiple consumers leaving/joining a consumer group works as expected.
