### PR TITLE
Kafka consumer group new

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ script:
     - cd build
     - make
     - go test github.com/mozilla-services/data-pipeline/s3splitfile
+    - go test github.com/mozilla-services/data-pipeline/kafkaconsumergroup

--- a/bin/build_pipeline_heka.sh
+++ b/bin/build_pipeline_heka.sh
@@ -74,6 +74,12 @@ if [ ! -f "patches_applied" ]; then
 
     echo "Adding external plugin for golang-lru output"
     echo "add_external_plugin(git https://github.com/mreid-moz/golang-lru acc5bd27065280640fa0a79a973076c6abaccec8)" >> cmake/plugin_loader.cmake
+
+    echo "Adding kafka consumer group input"
+    echo "add_external_plugin(git https://github.com/mozilla-services/data-pipeline/kafkaconsumergroup :local)" >> cmake/plugin_loader.cmake
+    echo "add_external_plugin(git https://github.com/wvanbergen/kafka master __ignore_root)" >> cmake/plugin_loader.cmake
+    echo "add_external_plugin(git https://github.com/wvanbergen/kazoo-go master)" >> cmake/plugin_loader.cmake
+    echo "add_external_plugin(git https://github.com/samuel/go-zookeeper master __ignore_root)" >> cmake/plugin_loader.cmake
 fi
 
 # TODO: do this using cmake externals instead of shell-fu.

--- a/bin/build_pipeline_heka.sh
+++ b/bin/build_pipeline_heka.sh
@@ -57,7 +57,7 @@ fi
 cd heka
 # pin the Heka version
 git fetch
-git checkout efab1d810e7482518fe6770e0145a5a64e7e787b
+git checkout 6f4b61a11cd01f1548dbd7dc8ebd0ed1cf9edbba
 
 if [ ! -f "patches_applied" ]; then
     touch patches_applied

--- a/bin/build_pipeline_heka.sh
+++ b/bin/build_pipeline_heka.sh
@@ -57,7 +57,7 @@ fi
 cd heka
 # pin the Heka version
 git fetch
-git checkout 6094d1db354301813384273e3e09fb33df8137c2
+git checkout efab1d810e7482518fe6770e0145a5a64e7e787b
 
 if [ ! -f "patches_applied" ]; then
     touch patches_applied
@@ -74,7 +74,6 @@ if [ ! -f "patches_applied" ]; then
 
     echo "Adding external plugin for golang-lru output"
     echo "add_external_plugin(git https://github.com/mreid-moz/golang-lru acc5bd27065280640fa0a79a973076c6abaccec8)" >> cmake/plugin_loader.cmake
-    echo "add_external_plugin(git https://github.com/golang/snappy master)" >> cmake/plugin_loader.cmake
 fi
 
 # TODO: do this using cmake externals instead of shell-fu.

--- a/heka/cmd/heka-s3cat/main.go
+++ b/heka/cmd/heka-s3cat/main.go
@@ -14,12 +14,12 @@ package main
 
 import (
 	"bufio"
-	"code.google.com/p/gogoprotobuf/proto"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"github.com/AdRoll/goamz/aws"
 	"github.com/AdRoll/goamz/s3"
+	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/mozilla-services/data-pipeline/s3splitfile"
 	"github.com/mozilla-services/heka/message"

--- a/heka/plugins/kafkaconsumergroup/kafka_consumer_group_input.go
+++ b/heka/plugins/kafkaconsumergroup/kafka_consumer_group_input.go
@@ -1,0 +1,255 @@
+/***** BEGIN LICENSE BLOCK *****
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# The Initial Developer of the Original Code is the Mozilla Foundation.
+# Portions created by the Initial Developer are Copyright (C) 2015
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#   Mike Trinkala (trink@mozilla.com)
+#   Rob Miller (rmiller@mozilla.com)
+#   Wesley Dawson (whd@mozilla.com)
+#
+# ***** END LICENSE BLOCK *****/
+
+package kafkaconsumergroup
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/mozilla-services/heka/message"
+	"github.com/mozilla-services/heka/pipeline"
+	"github.com/wvanbergen/kafka/consumergroup"
+	"github.com/wvanbergen/kazoo-go"
+
+	// "os"
+	// "log"
+)
+
+// FIXME can heka's logging infrastructure be used for this?
+// func init() {
+// 	sarama.Logger = log.New(os.Stdout, "[Sarama] ", log.LstdFlags)
+// }
+
+type KafkaConsumerGroupInputConfig struct {
+	Splitter string
+
+	// Client Config
+	MetadataRetries            int    `toml:"metadata_retries"`
+	WaitForElection            uint32 `toml:"wait_for_election"`
+	BackgroundRefreshFrequency uint32 `toml:"background_refresh_frequency"`
+
+	// Broker Config
+	MaxOpenRequests int    `toml:"max_open_reqests"`
+	DialTimeout     uint32 `toml:"dial_timeout"`
+	ReadTimeout     uint32 `toml:"read_timeout"`
+	WriteTimeout    uint32 `toml:"write_timeout"`
+
+	// Consumer Config
+	Partition                 int32
+	Group                     string
+	DefaultFetchSize          int32    `toml:"default_fetch_size"`
+	MinFetchSize              int32    `toml:"min_fetch_size"`
+	MaxMessageSize            int32    `toml:"max_message_size"`
+	MaxWaitTime               uint32   `toml:"max_wait_time"`
+	ConsumerGroup             string   `toml:"consumer_group"`
+	Topics                    []string `toml:"topics"`
+	ZookeeperConnectionString string   `toml:"zookeeper_connection_string"`
+}
+
+type KafkaConsumerGroupInput struct {
+	processMessageCount    int64
+	processMessageFailures int64
+
+	config         *KafkaConsumerGroupInputConfig
+	consumerConfig *consumergroup.Config
+	client         *sarama.Client
+	consumer       *consumergroup.ConsumerGroup
+	pConfig        *pipeline.PipelineConfig
+	ir             pipeline.InputRunner
+	stopChan       chan bool
+	name           string
+}
+
+func (k *KafkaConsumerGroupInput) ConfigStruct() interface{} {
+	return &KafkaConsumerGroupInputConfig{
+		Splitter:                   "NullSplitter",
+		MetadataRetries:            3,
+		WaitForElection:            250,
+		BackgroundRefreshFrequency: 10 * 60 * 1000,
+		MaxOpenRequests:            4,
+		DialTimeout:                60 * 1000,
+		ReadTimeout:                60 * 1000,
+		WriteTimeout:               60 * 1000,
+		DefaultFetchSize:           1024 * 32,
+		MinFetchSize:               1,
+		MaxWaitTime:                250,
+	}
+}
+
+func (k *KafkaConsumerGroupInput) SetPipelineConfig(pConfig *pipeline.PipelineConfig) {
+	k.pConfig = pConfig
+}
+
+func (k *KafkaConsumerGroupInput) SetName(name string) {
+	k.name = name
+}
+
+func (k *KafkaConsumerGroupInput) Init(config interface{}) (err error) {
+	k.config = config.(*KafkaConsumerGroupInputConfig)
+	if len(k.config.ConsumerGroup) == 0 {
+		return fmt.Errorf("consumer_group required")
+	}
+	if len(k.config.Topics) == 0 {
+		return fmt.Errorf("topics required")
+	}
+	if len(k.config.ZookeeperConnectionString) == 0 {
+		return fmt.Errorf("zookeeper_connection_string required")
+	}
+
+	k.consumerConfig = consumergroup.NewConfig()
+	k.consumerConfig.Offsets.Initial = sarama.OffsetOldest
+	k.consumerConfig.Offsets.ProcessingTimeout = 10 * time.Second
+
+	k.consumerConfig.Config.Metadata.Retry.Max = k.config.MetadataRetries
+	k.consumerConfig.Config.Metadata.Retry.Backoff = time.Duration(k.config.WaitForElection) * time.Millisecond
+	k.consumerConfig.Config.Metadata.RefreshFrequency = time.Duration(k.config.BackgroundRefreshFrequency) * time.Millisecond
+
+	k.consumerConfig.Config.Net.MaxOpenRequests = k.config.MaxOpenRequests
+	k.consumerConfig.Config.Net.DialTimeout = time.Duration(k.config.DialTimeout) * time.Millisecond
+	k.consumerConfig.Config.Net.ReadTimeout = time.Duration(k.config.ReadTimeout) * time.Millisecond
+	k.consumerConfig.Config.Net.WriteTimeout = time.Duration(k.config.WriteTimeout) * time.Millisecond
+
+	k.consumerConfig.Config.Consumer.Fetch.Default = k.config.DefaultFetchSize
+	k.consumerConfig.Config.Consumer.Fetch.Min = k.config.MinFetchSize
+	k.consumerConfig.Config.Consumer.Fetch.Max = k.config.MaxMessageSize
+	k.consumerConfig.Config.Consumer.MaxWaitTime = time.Duration(k.config.MaxWaitTime) * time.Millisecond
+
+	var zookeeperNodes []string
+	zookeeperNodes, k.consumerConfig.Zookeeper.Chroot = kazoo.ParseConnectionString(k.config.ZookeeperConnectionString)
+	if len(zookeeperNodes) == 0 {
+		return fmt.Errorf("unable to parse zookeeper_connection_string")
+	}
+
+	consumer, err := consumergroup.JoinConsumerGroup(k.config.ConsumerGroup, k.config.Topics, zookeeperNodes, k.consumerConfig)
+	if err != nil {
+		return
+	}
+	k.consumer = consumer
+	k.stopChan = make(chan bool)
+	return
+}
+
+func (k *KafkaConsumerGroupInput) addField(pack *pipeline.PipelinePack, name string,
+	value interface{}, representation string) {
+
+	if field, err := message.NewField(name, value, representation); err == nil {
+		pack.Message.AddField(field)
+	} else {
+		k.ir.LogError(fmt.Errorf("can't add '%s' field: %s", name, err.Error()))
+	}
+}
+
+func (k *KafkaConsumerGroupInput) Run(ir pipeline.InputRunner, h pipeline.PluginHelper) (err error) {
+	sRunner := ir.NewSplitterRunner("")
+
+	defer func() {
+		if err := k.consumer.Close(); err != nil {
+			k.ir.LogError(fmt.Errorf("error closing the consumer: %s", err.Error()))
+		}
+		sRunner.Done()
+	}()
+	k.ir = ir
+
+	go func() {
+		for err := range k.consumer.Errors() {
+			// this isn't a process message failure, as the failure channel is async
+			// atomic.AddInt64(&k.processMessageFailures, 1)
+			ir.LogError(err)
+		}
+	}()
+
+	var (
+		hostname = k.pConfig.Hostname()
+		event    *sarama.ConsumerMessage
+		ok       bool
+		n        int
+	)
+
+	packDec := func(pack *pipeline.PipelinePack) {
+		pack.Message.SetType("heka.kafka")
+		pack.Message.SetLogger(k.name)
+		pack.Message.SetHostname(hostname)
+		k.addField(pack, "Key", event.Key, "")
+		k.addField(pack, "Topic", event.Topic, "")
+		k.addField(pack, "Partition", event.Partition, "")
+		k.addField(pack, "Offset", event.Offset, "")
+	}
+	if !sRunner.UseMsgBytes() {
+		sRunner.SetPackDecorator(packDec)
+	}
+
+	offsets := make(map[string]map[int32]int64)
+	for {
+		select {
+		case event, ok = <-k.consumer.Messages():
+			if !ok {
+				return
+			}
+
+			if offsets[event.Topic] == nil {
+				offsets[event.Topic] = make(map[int32]int64)
+			}
+
+			if offsets[event.Topic][event.Partition] != 0 && offsets[event.Topic][event.Partition] != event.Offset-1 {
+				ir.LogError(fmt.Errorf("unexpected offset on %s:%d. Expected %d, found %d, diff %d.\n",
+					event.Topic, event.Partition,
+					offsets[event.Topic][event.Partition]+1, event.Offset,
+					event.Offset-offsets[event.Topic][event.Partition]+1))
+			}
+
+			atomic.AddInt64(&k.processMessageCount, 1)
+
+			if n, err = sRunner.SplitBytes(event.Value, nil); err != nil {
+				ir.LogError(fmt.Errorf("processing message from topic %s: %s",
+					event.Topic, err))
+			}
+			if n > 0 && n != len(event.Value) {
+				ir.LogError(fmt.Errorf("extra data dropped in message from topic %s",
+					event.Topic))
+			}
+
+			offsets[event.Topic][event.Partition] = event.Offset
+			k.consumer.CommitUpto(event)
+		case <-k.stopChan:
+			return
+		}
+	}
+}
+
+func (k *KafkaConsumerGroupInput) Stop() {
+	close(k.stopChan)
+}
+
+func (k *KafkaConsumerGroupInput) ReportMsg(msg *message.Message) error {
+	message.NewInt64Field(msg, "ProcessMessageCount",
+		atomic.LoadInt64(&k.processMessageCount), "count")
+	message.NewInt64Field(msg, "ProcessMessageFailures",
+		atomic.LoadInt64(&k.processMessageFailures), "count")
+	return nil
+}
+
+func (k *KafkaConsumerGroupInput) CleanupForRestart() {
+	return
+}
+
+func init() {
+	pipeline.RegisterPlugin("KafkaConsumerGroupInput", func() interface{} {
+		return new(KafkaConsumerGroupInput)
+	})
+}

--- a/heka/plugins/kafkaconsumergroup/kafka_consumer_group_input.go
+++ b/heka/plugins/kafkaconsumergroup/kafka_consumer_group_input.go
@@ -184,9 +184,7 @@ func (k *KafkaConsumerGroupInput) Run(ir pipeline.InputRunner, h pipeline.Plugin
 
 	go func() {
 		for err := range k.consumer.Errors() {
-			// this isn't necessarily a process message failure, as the failure
-			// channel is async
-			// atomic.AddInt64(&k.processMessageFailures, 1)
+			atomic.AddInt64(&k.processMessageFailures, 1)
 			ir.LogError(err)
 		}
 	}()

--- a/heka/plugins/kafkaconsumergroup/kafka_consumer_group_input_test.go
+++ b/heka/plugins/kafkaconsumergroup/kafka_consumer_group_input_test.go
@@ -10,6 +10,7 @@
 # Contributor(s):
 #   Mike Trinkala (trink@mozilla.com)
 #   Rob Miller (rmiller@mozilla.com)
+#   Wesley Dawson (whd@mozilla.com)
 #
 # ***** END LICENSE BLOCK *****/
 

--- a/heka/plugins/kafkaconsumergroup/kafka_consumer_group_input_test.go
+++ b/heka/plugins/kafkaconsumergroup/kafka_consumer_group_input_test.go
@@ -52,6 +52,25 @@ func TestBadZookeeperConnectionString(t *testing.T) {
 	}
 }
 
+func TestInvalidOffsetMethod(t *testing.T) {
+	pConfig := NewPipelineConfig(nil)
+	ki := new(KafkaConsumerGroupInput)
+	ki.SetName("test")
+	ki.SetPipelineConfig(pConfig)
+
+	config := ki.ConfigStruct().(*KafkaConsumerGroupInputConfig)
+	config.ConsumerGroup = "test"
+	config.Topics = []string{"test"}
+	config.ZookeeperConnectionString = "localhost:2181"
+	config.OffsetMethod = "last"
+	err := ki.Init(config)
+
+	errmsg := "invalid offset_method: last"
+	if err.Error() != errmsg {
+		t.Errorf("Expected: %s, received: %s", errmsg, err)
+	}
+}
+
 func TestEmptyInputTopics(t *testing.T) {
 	pConfig := NewPipelineConfig(nil)
 	ki := new(KafkaConsumerGroupInput)

--- a/heka/plugins/kafkaconsumergroup/kafka_consumer_group_input_test.go
+++ b/heka/plugins/kafkaconsumergroup/kafka_consumer_group_input_test.go
@@ -1,0 +1,83 @@
+/***** BEGIN LICENSE BLOCK *****
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# The Initial Developer of the Original Code is the Mozilla Foundation.
+# Portions created by the Initial Developer are Copyright (C) 2014-2015
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#   Mike Trinkala (trink@mozilla.com)
+#   Rob Miller (rmiller@mozilla.com)
+#
+# ***** END LICENSE BLOCK *****/
+
+package kafkaconsumergroup
+
+import (
+	"testing"
+
+	. "github.com/mozilla-services/heka/pipeline"
+)
+
+func TestEmptyZookeeperConnectionString(t *testing.T) {
+	pConfig := NewPipelineConfig(nil)
+	ki := new(KafkaConsumerGroupInput)
+	ki.SetPipelineConfig(pConfig)
+	config := ki.ConfigStruct().(*KafkaConsumerGroupInputConfig)
+	config.ConsumerGroup = "test"
+	config.Topics = []string{"test"}
+	err := ki.Init(config)
+
+	errmsg := "zookeeper_connection_string required"
+	if err.Error() != errmsg {
+		t.Errorf("Expected: %s, received: %s", errmsg, err)
+	}
+}
+
+func TestBadZookeeperConnectionString(t *testing.T) {
+	pConfig := NewPipelineConfig(nil)
+	ki := new(KafkaConsumerGroupInput)
+	ki.SetPipelineConfig(pConfig)
+	config := ki.ConfigStruct().(*KafkaConsumerGroupInputConfig)
+	config.ConsumerGroup = "test"
+	config.Topics = []string{"test"}
+	config.ZookeeperConnectionString = "::"
+	err := ki.Init(config)
+
+	errmsg := "zk: could not connect to a server"
+	if err.Error() != errmsg {
+		t.Errorf("Expected: %s, received: %s", errmsg, err)
+	}
+}
+
+func TestEmptyInputTopics(t *testing.T) {
+	pConfig := NewPipelineConfig(nil)
+	ki := new(KafkaConsumerGroupInput)
+	ki.SetPipelineConfig(pConfig)
+	config := ki.ConfigStruct().(*KafkaConsumerGroupInputConfig)
+	config.ConsumerGroup = "test"
+	config.ZookeeperConnectionString = "localhost:2181"
+	err := ki.Init(config)
+
+	errmsg := "topics required"
+	if err.Error() != errmsg {
+		t.Errorf("Expected: %s, received: %s", errmsg, err)
+	}
+}
+
+func TestMissingConsumerGroup(t *testing.T) {
+	pConfig := NewPipelineConfig(nil)
+	ki := new(KafkaConsumerGroupInput)
+	ki.SetPipelineConfig(pConfig)
+	config := ki.ConfigStruct().(*KafkaConsumerGroupInputConfig)
+	config.Topics = []string{"test"}
+	config.ZookeeperConnectionString = "localhost:2181"
+	err := ki.Init(config)
+
+	errmsg := "consumer_group required"
+	if err.Error() != errmsg {
+		t.Errorf("Expected: %s, received: %s", errmsg, err)
+	}
+}

--- a/heka/plugins/s3splitfile/s3splitfile_output.go
+++ b/heka/plugins/s3splitfile/s3splitfile_output.go
@@ -452,7 +452,7 @@ func (o *S3SplitFileOutput) receiver(or OutputRunner, wg *sync.WaitGroup) {
 			}
 			// else the encoder did not emit a message.
 
-			pack.Recycle()
+			pack.Recycle(nil)
 		case <-o.timerChan:
 			if e = o.rotateFiles(); e != nil {
 				or.LogError(fmt.Errorf("Error rotating files by time: %s", e))


### PR DESCRIPTION
Here's the consumer group code, finally mergable thanks to Rob's work on the upstream update_sarama branch. This PR also sets data-pipeline to point to heka's dev branch after update_sarama was merged, and includes parts of the local build_0.10 branch that didn't involve backporting snappy.

The only test coverage is for input validation, mostly due to my inability to find a way to easily mock the zookeeper infrastructure (this consumer group implementation uses the old-style zookeeper-based offsets). However, the code has undergone extensive testing over the last few weeks so I'm fairly confident it does what it's supposed to.
