### PR TITLE
Remove useless assignments.

### DIFF
--- a/heka/sandbox/filters/payload_size.lua
+++ b/heka/sandbox/filters/payload_size.lua
@@ -13,7 +13,7 @@ derived messages for reporting.
     [PayloadSize]
     type = "SandboxFilter"
     filename = "lua_filters/payload_size.lua"
-    message_matcher = "Type == 'telemetry'"
+    message_matcher = "Type == 'telemetry' && Logger == 'telemetry'"
     ticker_interval = 0
     preserve_data = false
 
@@ -21,8 +21,6 @@ derived messages for reporting.
 
 local msg = {
     Timestamp  = nil,
-    Type       = "payload_size",
-    Logger     = "telemetry",
     Payload    = nil,
     Fields     = {
         build = "",


### PR DESCRIPTION
Heka overwrites Type and Logger automatically. Type is replaced with
"heka.sandbox.stem", where "stem" is the filename of the lua filter
without the .lua file extension. Logger is replaced with the plugin
name.

So assigning to these two fields in the lua code has no effect.
