### PR TITLE
Add back the type to the payload_size filter

### DIFF
--- a/heka/sandbox/filters/payload_size.lua
+++ b/heka/sandbox/filters/payload_size.lua
@@ -21,6 +21,7 @@ derived messages for reporting.
 
 local msg = {
     Timestamp  = nil,
+    Type       = "payload_size",
     Payload    = nil,
     Fields     = {
         build = "",


### PR DESCRIPTION
Otherwise we get a Type of `heka.sandbox.`.
