### PR TITLE
Add dimension fields bug1191789

### DIFF
--- a/heka/plugins/s3splitfile/s3splitfile_common.go
+++ b/heka/plugins/s3splitfile/s3splitfile_common.go
@@ -62,11 +62,11 @@ func (s *Schema) GetDimensions(pack *PipelinePack) (dimensions []string) {
 		idx, ok := s.FieldIndices[field.GetName()]
 		if ok {
 			remaining -= 1
-			inValues := field.GetValueString()
-			if len(inValues) > 0 {
-				// We use the first available value, even if several have been
-				// provided.
-				v, err := s.GetValue(field.GetName(), inValues[0])
+			// We use the first available value, even if several have been
+			// provided.
+			inValue := field.GetValue()
+			if inValue != nil {
+				v, err := s.GetValue(field.GetName(), fmt.Sprintf("%v", inValue))
 				if err != nil {
 					fmt.Printf("How did this happen? %s", err)
 				}

--- a/heka/plugins/s3splitfile/s3splitfile_common.go
+++ b/heka/plugins/s3splitfile/s3splitfile_common.go
@@ -70,7 +70,9 @@ func (s *Schema) GetDimensions(pack *PipelinePack) (dimensions []string) {
 				if err != nil {
 					fmt.Printf("How did this happen? %s", err)
 				}
-				dims[idx] = v
+				if v != "" {
+					dims[idx] = v
+				} // Else the value was an empty string, leave as unknown.
 			} // Else there were no values, leave this field as unknown.
 		}
 	}

--- a/heka/plugins/s3splitfile/s3splitfile_common_test.go
+++ b/heka/plugins/s3splitfile/s3splitfile_common_test.go
@@ -7,6 +7,8 @@
 package s3splitfile
 
 import (
+	"github.com/mozilla-services/heka/message"
+	. "github.com/mozilla-services/heka/pipeline"
 	gs "github.com/rafrombrc/gospec/src/gospec"
 	"path/filepath"
 )
@@ -65,5 +67,36 @@ func S3SplitFileSpec(c gs.Context) {
 		testFieldVal(c, schema, "range", "aa0", "OTHER")
 		testFieldVal(c, schema, "range", "bbc", "OTHER")
 		testFieldVal(c, schema, "range", "ccc", "OTHER")
+	})
+
+	c.Specify("Non-string fields", func() {
+		schema, _ := LoadSchema(filepath.Join(".", "testsupport", "schema.json"))
+		pack := NewPipelinePack(nil)
+
+		// No fields
+		dims := schema.GetDimensions(pack)
+		c.Expect(dims[0], gs.Equals, "UNKNOWN")
+
+		// Integer field
+		f, _ := message.NewField("any", 1, "")
+		pack.Message.AddField(f)
+		dims = schema.GetDimensions(pack)
+		c.Expect(dims[0], gs.Equals, "1")
+		pack.Message.DeleteField(f)
+
+		// Boolean field
+		f, _ = message.NewField("any", true, "")
+		pack.Message.AddField(f)
+		dims = schema.GetDimensions(pack)
+		c.Expect(dims[0], gs.Equals, "true")
+		pack.Message.DeleteField(f)
+
+		// Double field
+		f, _ = message.NewField("any", 1.23, "")
+		pack.Message.AddField(f)
+		dims = schema.GetDimensions(pack)
+		c.Expect(dims[0], gs.Equals, "1.23")
+		pack.Message.DeleteField(f)
+
 	})
 }

--- a/heka/plugins/s3splitfile/s3splitfile_common_test.go
+++ b/heka/plugins/s3splitfile/s3splitfile_common_test.go
@@ -98,5 +98,12 @@ func S3SplitFileSpec(c gs.Context) {
 		c.Expect(dims[0], gs.Equals, "1.23")
 		pack.Message.DeleteField(f)
 
+		// Empty string field
+		f, _ = message.NewField("any", "", "")
+		pack.Message.AddField(f)
+		dims = schema.GetDimensions(pack)
+		c.Expect(dims[0], gs.Equals, "UNKNOWN")
+		pack.Message.DeleteField(f)
+
 	})
 }

--- a/heka/sandbox/decoders/extract_telemetry_dimensions.lua
+++ b/heka/sandbox/decoders/extract_telemetry_dimensions.lua
@@ -125,8 +125,8 @@ local function process_json(msg, json, parsed)
         update_field(msg.Fields, "appBuildId"        , info.appBuildID or UNK_DIM)
         update_field(msg.Fields, "normalizedChannel" , fx.normalize_channel(info.appUpdateChannel))
 
-        -- Old telemetry was always "extended"
-        update_field(msg.Fields, "isExtended"        , true)
+        -- Old telemetry was always "enabled"
+        update_field(msg.Fields, "telemetryEnabled"  , true)
 
         -- Do not want default values for these.
         update_field(msg.Fields, "os"        , info.OS)
@@ -154,7 +154,7 @@ local function process_json(msg, json, parsed)
                    update_field(msg.Fields, "os", parsed.environment.system.os.name)
             end
             if type(parsed.environment.settings) == "table" then
-                update_field(msg.Fields, "isExtended", parsed.environment.settings.telemetryEnabled)
+                update_field(msg.Fields, "telemetryEnabled", parsed.environment.settings.telemetryEnabled)
             end
         end
 
@@ -212,7 +212,7 @@ local function process_json(msg, json, parsed)
         update_field(msg.Fields, "appBuildId"        , abi or UNK_DIM)
         update_field(msg.Fields, "normalizedChannel" , fx.normalize_channel(auc))
 
-        -- The "isExtended" flag does not apply to this type of ping.
+        -- The "telemetryEnabled" flag does not apply to this type of ping.
     end
     update_field(msg.Fields, "sampleId", sample(clientId, 100))
     return nil -- processing was successful

--- a/heka/sandbox/decoders/extract_telemetry_dimensions.lua
+++ b/heka/sandbox/decoders/extract_telemetry_dimensions.lua
@@ -7,6 +7,7 @@ require "cjson"
 require "hash"
 require "os"
 require "table"
+local fx = require "fx"
 local gzip = require "gzip"
 local dt = require("date_time")
 
@@ -122,6 +123,10 @@ local function process_json(msg, json, parsed)
         update_field(msg.Fields, "appVersion"        , info.appVersion or UNK_DIM)
         update_field(msg.Fields, "appUpdateChannel"  , info.appUpdateChannel or UNK_DIM)
         update_field(msg.Fields, "appBuildId"        , info.appBuildID or UNK_DIM)
+        update_field(msg.Fields, "normalizedChannel" , fx.normalize_channel(info.appUpdateChannel))
+
+        -- Old telemetry was always "extended"
+        update_field(msg.Fields, "isExtended"        , true)
 
         -- Do not want default values for these.
         update_field(msg.Fields, "os"        , info.OS)
@@ -143,20 +148,24 @@ local function process_json(msg, json, parsed)
                update_field(msg.Fields, "reason", parsed.payload.info.reason)
         end
 
-        if type(parsed.environment) == "table" and
-           type(parsed.environment.system) == "table" and
-           type(parsed.environment.system.os) == "table" then
-               update_field(msg.Fields, "os", parsed.environment.system.os.name)
+        if type(parsed.environment) == "table" then
+            if type(parsed.environment.system) == "table" and
+               type(parsed.environment.system.os) == "table" then
+                   update_field(msg.Fields, "os", parsed.environment.system.os.name)
+            end
+            if type(parsed.environment.settings) == "table" then
+                update_field(msg.Fields, "isExtended", parsed.environment.settings.telemetryEnabled)
+            end
         end
 
+        -- Get some more dimensions.
         update_field(msg.Fields, "sourceVersion", tostring(parsed.version))
         update_field(msg.Fields, "docType"      , parsed.type or UNK_DIM)
-
-        -- Get some more dimensions.
         update_field(msg.Fields, "appName"           , app.name or UNK_DIM)
         update_field(msg.Fields, "appVersion"        , app.version or UNK_DIM)
         update_field(msg.Fields, "appUpdateChannel"  , app.channel or UNK_DIM)
         update_field(msg.Fields, "appBuildId"        , app.buildId or UNK_DIM)
+        update_field(msg.Fields, "normalizedChannel" , fx.normalize_channel(app.channel))
 
         -- Do not want default values for these.
         update_field(msg.Fields, "appVendor" , app.vendor)
@@ -201,6 +210,9 @@ local function process_json(msg, json, parsed)
         update_field(msg.Fields, "appVersion"        , av or UNK_DIM)
         update_field(msg.Fields, "appUpdateChannel"  , auc or UNK_DIM)
         update_field(msg.Fields, "appBuildId"        , abi or UNK_DIM)
+        update_field(msg.Fields, "normalizedChannel" , fx.normalize_channel(auc))
+
+        -- The "isExtended" flag does not apply to this type of ping.
     end
     update_field(msg.Fields, "sampleId", sample(clientId, 100))
     return nil -- processing was successful


### PR DESCRIPTION
Bug 1191789 intends to add extra dimensions to the "release" data. This PR adds support for using non-string fields as dimensions (boolean for `isExtended`, int for `sampleId`), as well as adding the required extra fields to the decoder.
