### PR TITLE
Escape NUL character in the psv

### DIFF
--- a/hindsight/io_modules/derived_stream/redshift/psv.lua
+++ b/hindsight/io_modules/derived_stream/redshift/psv.lua
@@ -13,13 +13,15 @@ local string    = require "string"
 
 setfenv(1, M) -- Remove external access to contain everything in the module
 
-local esc_chars = { ["|"] = "\\|", ["\r"] = "\\r", ["\n"] = "\\n", ["\0"] = "0" }
+local esc_chars = { ["|"] = "\\|", ["\r"] = "\\r", ["\n"] = "\\n" }
 function esc_varchar(v, max)
     if v == nil then return "" end
     if max == nil then max = rs.VARCHAR_MAX_LENGTH end
     if type(v) ~= "string" then v = tostring(v) end
     if string.len(v) > max then v = string.sub(v, 1, max) end
-    return string.gsub(v, "[|\r\n%z]", esc_chars)
+    local s, e = string.find(v, "%z")
+    if s then string.sub(v, 1, s-1) end
+    return string.gsub(v, "[|\r\n]", esc_chars)
 end
 
 function write_message(fh, schema)

--- a/hindsight/io_modules/derived_stream/redshift/psv.lua
+++ b/hindsight/io_modules/derived_stream/redshift/psv.lua
@@ -13,13 +13,13 @@ local string    = require "string"
 
 setfenv(1, M) -- Remove external access to contain everything in the module
 
-local esc_chars = { ["|"] = "\\|", ["\r"] = "\\r", ["\n"] = "\\n" }
+local esc_chars = { ["|"] = "\\|", ["\r"] = "\\r", ["\n"] = "\\n", ["\0"] = "0" }
 function esc_varchar(v, max)
     if v == nil then return "" end
     if max == nil then max = rs.VARCHAR_MAX_LENGTH end
     if type(v) ~= "string" then v = tostring(v) end
     if string.len(v) > max then v = string.sub(v, 1, max) end
-    return string.gsub(v, "[|\r\n]", esc_chars)
+    return string.gsub(v, "[|\r\n%z]", esc_chars)
 end
 
 function write_message(fh, schema)


### PR DESCRIPTION
- Redshift treats them as an end of record (EOR) marker, causing the
  remainder of the record to be truncated
