### PR TITLE
Fix the broken redshift/s3 insert/copy retry logic

### DIFF
--- a/hindsight/io_modules/derived_stream/redshift.lua
+++ b/hindsight/io_modules/derived_stream/redshift.lua
@@ -24,7 +24,9 @@ function strip_nonprint(v)
 end
 
 function esc_timestamp(v, default)
-    if type(v) ~= "number" then return default end
+    if type(v) ~= "number" or v > 4294967296e9 or v < 0 then
+        return default
+    end
     return date("%Y-%m-%d %H:%M:%S.", floor(v / 1e9)) .. tostring(floor(v % 1e9 / 1e3))
 end
 

--- a/hindsight/io_modules/derived_stream/redshift/psv.lua
+++ b/hindsight/io_modules/derived_stream/redshift/psv.lua
@@ -20,7 +20,7 @@ function esc_varchar(v, max)
     if type(v) ~= "string" then v = tostring(v) end
     if string.len(v) > max then v = string.sub(v, 1, max) end
     local s, e = string.find(v, "%z")
-    if s then string.sub(v, 1, s-1) end
+    if s then v = string.sub(v, 1, s-1) end
     return string.gsub(v, "[|\r\n]", esc_chars)
 end
 


### PR DESCRIPTION
- preserve the file object for the retry
- attempt 1 retry on shutdown and report error on failure
- range check the timestamp to prevent conversion failures
