### PR TITLE
Need to put `error` in sql.lua local namespace since it's used in the…

### DIFF
--- a/hindsight/io_modules/derived_stream/redshift/sql.lua
+++ b/hindsight/io_modules/derived_stream/redshift/sql.lua
@@ -3,6 +3,7 @@
 -- file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 local M = {}
+local error = error
 local ipairs = ipairs
 local read_message = read_message
 local tostring = tostring


### PR DESCRIPTION
… module.
