### PR TITLE
fix gnu/bsd incompatibilities.

### DIFF
--- a/bin/build_pipeline_heka.sh
+++ b/bin/build_pipeline_heka.sh
@@ -19,9 +19,9 @@ Darwin)
     echo "Ensuring we have the latest geoip for OSX..."
     MIN_GEOIP_VER=1.6.3
     if [ ! -z "$(which brew)" ]; then
-        OSX_GEO_VER=$(brew info geoip | grep "geoip:" | sed -r "s/^.* ([0-9]+[.][0-9]+[.][0-9]+) .*$/\1/")
+      OSX_GEO_VER=$(brew info geoip | grep "geoip:" | cut -d\  -f3)
         if [ ! -z "$OSX_GEO_VER" ]; then
-            X=$(printf '%s\n%s' "$MIN_GEOIP_VER" "$OSX_GEO_VER" | sort -V | head -1)
+            X=$(printf '%s\n%s' "$MIN_GEOIP_VER" "$OSX_GEO_VER" | sort | head -1)
             if [ "$X" != "$MIN_GEOIP_VER" ]; then
                 echo "Existing geoip version ($OSX_GEO_VER) is too old (we need at least $MIN_GEOIP_VER). Upgrading..."
                 brew upgrade geoip


### PR DESCRIPTION
OSX/BSD `sort` lacks `-V`, and `sed` lacks `-r`.

Still a remaining bug in that this only checks geoip version in brew and doesn't ensure that its actually installed.
