### PR TITLE
Add a filter to emit the webrtc derived stream

### DIFF
--- a/heka/sandbox/filters/telemetry_webrtc.lua
+++ b/heka/sandbox/filters/telemetry_webrtc.lua
@@ -21,9 +21,9 @@ Derived stream for webrtc. https://bugzilla.mozilla.org/show_bug.cgi?id=1231410
 require 'cjson'
 
 local function check_payload (payload)
-    local w = payload['webrtc'] or {}
-    local i = w['IceCandidatesStats'] or {}
-    if next(i['webrtc'] or {}) or next(i['loop'] or {}) then
+    local w = payload["webrtc"] or {}
+    local i = w["IceCandidatesStats"] or {}
+    if next(i["webrtc"] or {}) or next(i["loop"] or {}) then
         return true
     end
     return false
@@ -32,13 +32,13 @@ end
 function process_message()
     local ok, json = pcall(cjson.decode, read_message("Payload"))
     if not ok then return -1, json end
-    local p = json['payload'] or {}
+    local p = json["payload"] or {}
     local found = check_payload(p)
     if not found then
         -- check child payloads for E10s
         local children = read_message("Fields[payload.childPayloads]")
         if not children then return 0 end
-        local ok, json = pcall(cjson.decode, children)
+        ok, json = pcall(cjson.decode, children)
         if not ok then return -1, children end
         if type(json) ~= "table" then return -1 end
         for i, child in ipairs(json) do

--- a/heka/sandbox/filters/telemetry_webrtc.lua
+++ b/heka/sandbox/filters/telemetry_webrtc.lua
@@ -1,0 +1,42 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+--[[
+Derived stream for webrtc. https://bugzilla.mozilla.org/show_bug.cgi?id=1231410
+
+*Example Heka Configuration*
+
+.. code-block:: ini
+
+    [TelemetryWebRTC]
+    type = "SandboxFilter"
+    filename = "lua_filters/telemetry_webrtc.lua"
+    message_matcher = "Type == 'telemetry' && Logger == 'telemetry'"
+    ticker_interval = 0
+    preserve_data = false
+
+--]]
+
+require 'cjson'
+
+function process_message()
+    local raw = read_message("raw")
+    local payload, json = pcall(cjson.decode, read_message("Payload"))
+    if not payload then return -1, json end
+    local p = json['payload'] or {}
+    local w = p['webrtc'] or {}
+    local i = w['IceCandidatesStats'] or {}
+    if next(i['webrtc'] or {}) or next(i['loop'] or {}) then
+        inject_message(raw)
+        return 0
+    end
+    -- FIXME I'm guessing we should also examine child payloads
+    -- local payload, json = pcall(cjson.decode, read_message("Fields[payload.childPayloads]"))
+    -- if not payload then return -1, json end
+    return 0
+end
+
+function timer_event(ns)
+    -- no op
+end


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1231410

I'm using `read_message("raw")` when needed but not `decode_message` to decode the entire message always under the assumption that it's slightly more efficient to do it this way.
