### PR TITLE
Type check the inner payload for telemetry webrtc

### DIFF
--- a/heka/sandbox/filters/telemetry_webrtc.lua
+++ b/heka/sandbox/filters/telemetry_webrtc.lua
@@ -21,6 +21,7 @@ Derived stream for webrtc. https://bugzilla.mozilla.org/show_bug.cgi?id=1231410
 require 'cjson'
 
 local function check_payload (payload)
+    if type(payload) ~= "table" then return false end
     local w = payload["webrtc"] or {}
     local i = w["IceCandidatesStats"] or {}
     if next(i["webrtc"] or {}) or next(i["loop"] or {}) then


### PR DESCRIPTION
`payload` was a number at least once in prod. https://github.com/mozilla-services/puppet-config/pull/1731 for better monitoring.
