### PR TITLE
Handle 'core' pings, update example config.

### DIFF
--- a/examples/decode_telemetry.toml
+++ b/examples/decode_telemetry.toml
@@ -34,7 +34,7 @@ memory_limit = 90000000
 output_limit = 8388608
     [HttpEdgeDecoder.config]
     geoip_city_db = "GeoLiteCity.dat"
-    namespace_config = '{"test":{"logger":"test_input","max_path_length":20480,"max_data_length":1048576},"telemetry":{"dimensions":["reason","appName","appVersion","appUpdateChannel","appBuildID"],"max_path_length":10240,"max_data_length":204800}}'
+    namespace_config = '{"test":{"logger":"test_input","max_path_length":20480,"max_data_length":1048576},"telemetry":{"dimensions":["docType","appName","appVersion","appUpdateChannel","appBuildId"],"max_path_length":10240,"max_data_length":204800}}'
 
 [TelemetryDecoder]
 type = "SandboxDecoder"

--- a/heka/sandbox/decoders/extract_telemetry_dimensions.lua
+++ b/heka/sandbox/decoders/extract_telemetry_dimensions.lua
@@ -230,6 +230,15 @@ local function process_json(msg, json, parsed)
         update_field(msg.Fields, "normalizedChannel" , fx.normalize_channel(auc))
 
         -- The "telemetryEnabled" flag does not apply to this type of ping.
+    elseif parsed.v then
+        -- This is a Fennec "core" ping
+        update_field(msg.Fields, "sourceVersion", tostring(parsed.v))
+        clientId = parsed.clientId
+        update_field(msg.Fields, "clientId", clientId)
+        msg.Payload = json
+    else
+        -- Everything else. Just store the submission in the Payload field by default.
+        msg.Payload = json
     end
     update_field(msg.Fields, "sampleId", sample(clientId, 100))
     return nil -- processing was successful


### PR DESCRIPTION
Detect and store 'core' pings. For unrecognized Telemetry ping types,
store the JSON submission in the Payload field by default.

Also update the example decoding config to use the standard field
names.
