### PR TITLE
Add near-realtime Firefox ADI data export

### DIFF
--- a/heka/sandbox/export_to_s3.lua
+++ b/heka/sandbox/export_to_s3.lua
@@ -1,0 +1,66 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
+require "io"
+require "os"
+require "string"
+ 
+--[[
+*Example Configuration*
+    This stores the text Payload field of any matched message to disk in temp_dir
+    and copies the file to S3 in s3_dir.
+    The file will be named from the messages fields per the pattern: <Logger>.<payload_name>.<payload_type>
+    ... with any non-alphanumeric characters substituted with '_'.
+
+    [S3Output]
+    type = "SandboxOutput"
+    filename = "export_to_s3.lua"
+    message_matcher = "Type == 'heka.sandbox.FirefoxADIRolling.json'"
+    ticker_interval = 0
+
+    [S3Output.config]
+    temp_dir = "/temp/path"
+    s3_dir = "s3://test"
+--]]
+
+local temp_dir = read_config("temp_dir") or error("temp_dir must be set")
+local s3_dir = read_config("s3_dir") or error("s3_path must be set")
+ 
+function process_message()
+    local pt = read_message("Fields[payload_type]")
+    if type(pt) ~= "string" then return -1, "invalid payload_type" end
+ 
+    local pn = read_message("Fields[payload_name]") or ""
+    if type(pn) ~= "string" then return -1, "invalid payload_name" end
+ 
+    local logger = read_message("Logger") or ""
+ 
+    pn = string.gsub(pn, "[^%w_]", "_")
+    pt = string.gsub(pt, "[^%w_]", "_")
+    logger = string.gsub(logger, "[^%w_]", "_")
+ 
+    local filename = string.format("%s.%s.%s", logger, pn, pt)
+    local temp_path = string.format("%s/%s", temp_dir, filename)
+    local s3_cmd = string.format("aws s3 cp %s %s/%s", temp_path, s3_dir, filename)
+
+    local fh, err = io.open(temp_path, "w")
+    if err then return -1, err end
+ 
+    local payload = read_message("Payload") or ""
+    fh:write(payload)
+    fh:close()
+
+    local ret = os.execute(s3_cmd)
+    if ret ~= 0 then
+        return -1, string.format("ret: %d, cmd: %s", ret, s3_cmd)
+    end
+
+    os.remove(temp_path)
+ 
+    return 0
+end
+ 
+function timer_event(ns)
+    -- no op
+end 

--- a/heka/sandbox/filters/firefox_adi_rolling.lua
+++ b/heka/sandbox/filters/firefox_adi_rolling.lua
@@ -1,0 +1,158 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+--[[
+Firefox Active Instances
+
+The memory requirements for this are roughly:
+12kb hyperloglog * framecount * 2 channels * ~50 versions
+
+Note that the version count is just a rough guess for upper limits, we will
+have to finetune this from real-world data.
+
+*Example Heka Configuration*
+
+.. code-block:: ini
+
+    [FirefoxADIRolling]
+    type = "SandboxFilter"
+    filename = "lua_filters/firefox_adi_rolling.lua"
+    message_matcher = "Logger == 'fx' && Type == 'executive_summary' && Fields[vendor] == 'Mozilla' && Fields[app] == 'Firefox'"
+    memory_limit = 300000000
+    ticker_interval = 60
+    preserve_data = true
+--]]
+require "cjson"
+require "math"
+require "os"
+require "hyperloglog"
+
+local SEC_IN_DAY = 60 * 60 * 24
+local floor = math.floor
+
+-- We track active Firefox instances for a window of ACTIVE_INTERVAL_IN_SEC,
+-- in frames that span FRAME_SIZE_IN_SEC.
+-- This is a near-real-time rolling window of active instances, so the current
+-- frame is determined by the current server time.
+-- We add one frame to actually look back over the whole ACTIVE_INTERVAL_IN_SEC.
+local FRAME_SIZE_SEC = 15 * 60
+local ACTIVITY_WINDOW_SEC = SEC_IN_DAY
+local FRAME_COUNT = floor(ACTIVITY_WINDOW_SEC / FRAME_SIZE_SEC) + 1
+
+-- This holds an array of frames.
+-- Each frame contains a table mapping versions to hyperloglogs.
+local active_instances = {}
+for i=1,FRAME_COUNT do
+    active_instances[i] = {
+        beta = {},
+        release = {},
+    }
+end
+
+-- The last time we updated the ADI frames, in seconds.
+local last_update = -1
+
+local function clear_frame(frame)
+    for channel,data in pairs(active_instances[frame]) do
+        active_instances[frame][channel] = {}
+    end
+end
+
+local function get_frame_hll(frame, channel, version)
+    local data = active_instances[frame][channel]
+    if data[version] == nil then
+        data[version] = hyperloglog.new()
+    end
+    return data[version]
+end
+
+local function get_oldest_frame(now)
+    local oldest_frame = (floor(now / FRAME_SIZE_SEC) + 1) % FRAME_COUNT
+    return active_instances[oldest_frame + 1]
+end
+
+local function update_activity(cid, channel, version, timestamp_ns)
+    -- os.time() returns seconds, rounding down the message timestamp avoids
+    -- issues comparing to this.
+    local ts = floor(timestamp_ns / 1e9)
+    local now = os.time()
+
+    -- Ignore messages that are too old or from the future.
+    -- This makes things work properly with backfill and odd messages.
+    if (ts > now) or ((now - ts) > ACTIVITY_WINDOW_SEC) then
+        return
+    end
+
+    local now_frame = floor(now / FRAME_SIZE_SEC) % FRAME_COUNT
+    local oldest_frame = (now_frame + 1) % FRAME_COUNT
+    local last_frame = floor(last_update / FRAME_SIZE_SEC) % FRAME_COUNT
+    local msg_frame = floor(ts / FRAME_SIZE_SEC) % FRAME_COUNT
+
+    -- If all frames went outside the activity window since the last message,
+    -- clear out everything.
+    if (now - last_update) > ACTIVITY_WINDOW_SEC then
+        for i=1,FRAME_COUNT do
+            clear_frame(i)
+        end
+    -- If the current frame changed since the last message, clear out all frames
+    -- since then and the current one.
+    elseif last_frame ~= now_frame then
+        local from = (last_frame + 1) % FRAME_COUNT
+        local steps = (now_frame - from) % FRAME_COUNT
+
+        for i=from,from+steps do
+            clear_frame((i % FRAME_COUNT) + 1)
+        end
+    end
+
+    -- Loop through the circular buffer, marking this client as seen from
+    -- the oldest time frame up to the messages frame.
+    local steps = (msg_frame - oldest_frame) % FRAME_COUNT
+    for i=oldest_frame,oldest_frame+steps do
+        get_frame_hll((i % FRAME_COUNT) + 1, channel, version):add(cid)
+    end
+
+    last_update = now
+end
+
+function process_message()
+    local ts  = read_message("Timestamp")
+    local cid = read_message("Fields[clientId]")
+    local version = read_message("Fields[version]")
+    local channel = read_message("Fields[channel]")
+
+    local function is_nonempty_string(s)
+        return type(s) == "string" and s ~= ""
+    end
+
+    if is_nonempty_string(cid) and is_nonempty_string(version) and
+       is_nonempty_string(channel) and
+       (channel == "release" or channel == "beta") then
+        update_activity(cid, channel, version, ts)
+    end
+
+    return 0
+end
+
+function timer_event(ns)
+    local now = os.time()
+    local json = {
+        updateTimestamp = now * 1e3,
+        adi = {},
+    }
+
+    if (now - last_update) <= ACTIVITY_WINDOW_SEC then
+        local frame = get_oldest_frame(now)
+        for channel,data in pairs(frame) do
+            json.adi[channel] = {}
+            for version,hll in pairs(data) do
+                json.adi[channel][version] = hll:count()
+            end
+        end
+    end
+
+    -- TODO: Currently we only display this in the Heka dashboard.
+    -- This data needs to be published to S3 for consumption by other teams.
+    inject_payload("json", "Firefox ADI Rolling", cjson.encode(json))
+end


### PR DESCRIPTION
This adds the pipeline filter & output required for [bug 1240522](https://bugzilla.mozilla.org/show_bug.cgi?id=1240522).

The idea is to track active client IDs per channel and version in hyperloglogs for a 24h window in 15min time slices, then regularly publish that data as JSON in a protected S3 bucket.
Users of the data would grab the JSON from there, e.g. via the metrics dashboard setup.

**Open issues**
- Do we need to be more clever about when to send (and consequently push to S3) new ADI JSON messages?
  - If this is something to worry about, we could presumably e.g. track when we switched to a new frame / ADI slice
  - ... or sync frame changes & timer_event()s properly, if that is possible
- I wasn't sure where `export_to_s3.lua` is supposed to live, just dropped it into `heka/sandbox/` for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-services/data-pipeline/190)
<!-- Reviewable:end -->
