### PR TITLE
Skip the telemetry decode unless Logger==telemetry

### DIFF
--- a/examples/decode_telemetry.toml
+++ b/examples/decode_telemetry.toml
@@ -34,7 +34,7 @@ memory_limit = 90000000
 output_limit = 8388608
     [HttpEdgeDecoder.config]
     geoip_city_db = "GeoLiteCity.dat"
-    namespace_config = '{"test":{"logger":"test_input","max_path_length":20480,"max_data_length":1048576},"telemetry":{"dimensions":["docType","appName","appVersion","appUpdateChannel","appBuildId"],"max_path_length":10240,"max_data_length":204800}}'
+    namespace_config = '{"test":{"logger":"test_input","max_path_length":20480,"max_data_length":1048576},"telemetry":{"dimensions":["docType","appName","appVersion","appUpdateChannel","appBuildId"],"max_path_length":10240,"max_data_length":204800},"sslreports":{"max_path_length":1024,"max_data_length":1048576}}'
 
 [TelemetryDecoder]
 type = "SandboxDecoder"

--- a/heka/sandbox/decoders/extract_telemetry_dimensions.lua
+++ b/heka/sandbox/decoders/extract_telemetry_dimensions.lua
@@ -272,6 +272,11 @@ function process_message()
     local ok, msg = pcall(decode_message, raw)
     if not ok then return -1, msg end
 
+    -- Skip non-telemetry messages.
+    if msg.Logger ~= "telemetry" then
+        return 0
+    end
+
     msg.Type = "telemetry"
     msg.EnvVersion = 1
     if not msg.Fields then msg.Fields = {} end


### PR DESCRIPTION
This avoids creating a "telemetry-error" message for sslreports
submissions, for example. Relates to bug 1253474.

Since we don't have a message_matcher for decoders, we check
the Logger for the expected value before attempting to decode a
telemetry message.

r? @trink 
