### PR TITLE
Improve sandbox support for getting Heka data in/out of S3

### DIFF
--- a/hindsight/input/heka_s3.lua
+++ b/hindsight/input/heka_s3.lua
@@ -1,0 +1,91 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+--[[
+## Reader for the S3 Heka files in compressed or uncompressed form
+
+Retrieves/reads each file from the `s3_file_list`. The primary use of this
+plugin is to feed the transformed/validated data into analysis plugins.
+
+### Sample Configuration
+```lua
+filename        = "heka_s3.lua"
+s3_bucket       = "net-mozaws-prod-us-west-2-pipeline-data"
+s3_file_list    = "files.ls.1"
+tmp_dir         = "/mnt/work/tmp"
+```
+--]]
+
+require "io"
+require "heka_stream_reader"
+require "os"
+require "string"
+
+local tmp_dir       = read_config("tmp_dir")
+local s3_bucket     = read_config("s3_bucket") or error("s3_bucket must be set")
+local logger        = read_config("Logger")
+local s3_file_list  = assert(io.open(read_config("s3_file_list")))
+
+
+local function process_file(hsr, fn)
+    local fh, err = io.open(fn)
+    if not fh then
+        print("failed to open", fn)
+        return
+    end
+
+    local found, consumed, read
+    repeat
+        repeat
+            found, consumed, read = hsr:find_message(fh)
+            if found then
+                inject_message(hsr)
+            end
+        until not found
+    until read == 0
+    fh:close()
+end
+
+
+local function execute_cmd(cmd, retries)
+    local rv = 1
+    for i=1, retries do
+        rv = os.execute(cmd)
+        if rv == 0 then
+            break
+        end
+    end
+    return rv
+end
+
+
+function process_message()
+    local hsr  = heka_stream_reader.new("s3")
+
+    for fn in s3_file_list:lines() do
+        local cmd
+        local tfn = string.format("%s/%s", tmp_dir, logger)
+        local ext = fn:match("%.([^.]-)$")
+        if ext == "zst" then
+            cmd = string.format("aws s3 cp s3://%s/%s - | zstd -d -c - > %s", s3_bucket, fn, tfn)
+        elseif ext == "gz" then
+            cmd = string.format("aws s3 cp s3://%s/%s - | gzip -d -c - > %s", s3_bucket, fn, tfn)
+        else
+            cmd = string.format("aws s3 cp s3://%s/%s %s", s3_bucket, fn, tfn)
+        end
+
+        print("processing", cmd)
+        local rv = execute_cmd(cmd, 3)
+        if rv == 0 then
+            process_file(hsr, tfn, compression)
+        else
+            print("failed to execute rv:", rv, " cmd:", cmd)
+        end
+    end
+    return 0
+end

--- a/hindsight/input/serverlog_s3_bootstrap.lua
+++ b/hindsight/input/serverlog_s3_bootstrap.lua
@@ -1,0 +1,159 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+--[[
+## Heka S3 server log data input plugin bootstrapper
+
+This plugin:
+
+1. retrieves a list of files from S3 matching the `service` log name and the date range
+1. divides the list among the specified number of `partitions`
+1. generates the cfgs to dynamically start a new reader for each partition;
+   the specified `input_plugin` should already be installed in run/input
+1. exits when the bootstrapping is complete
+
+### Sample Configuration
+```lua
+filename            = "serverlog_s3_bootstrap.lua"
+instruction_limit   = 0
+ticker_interval     = 0
+
+input_plugin        = "heka_s3.lua"
+input_plugin_cfgs   = {} -- table of plugin specific config options
+tmp_dir             = "/mnt/work/tmp"
+s3_bucket           = "heka-logs"
+s3_prefix           = "shared"
+start_date          = "2016-04-01"
+end_date            = "2016-04-07"
+service             = "loop-app"
+partitions          = 1
+```
+--]]
+
+require "io"
+require "os"
+require "string"
+
+local input_plugin      = read_config("input_plugin")
+local input_plugin_cfgs = read_config("input_plugin_cfgs") or {}
+local tmp_dir           = read_config("tmp_dir")
+local s3_bucket         = read_config("s3_bucket") or error("s3_bucket must be set")
+local s3_prefix         = read_config("s3_prefix")
+local service           = read_config("service") or error("service must be set")
+local start_date        = read_config("start_date")
+local end_date          = read_config("end_date")
+local sblp              = read_config("sandbox_load_path")
+local partitions        = tonumber(read_config("partitions"))
+local list_file         = string.format("%s/%s.ls", tmp_dir, service)
+local tmp_file          = string.format("%s/%s.tmp", tmp_dir, service)
+
+if not partitions or partitions < 1 then error("partitions must be set > 0") end
+
+local DATE_FORMAT           = "^(%d%d%d%d)%-(%d%d)%-(%d%d)$"
+local syear, smonth, sday   = start_date:match(DATE_FORMAT)
+start_date                  = os.time({year = syear, month = smonth, day = sday})
+
+local eyear, emonth, eday   = end_date:match(DATE_FORMAT)
+end_date                    = os.time({year = eyear, month = emonth, day = eday})
+assert(end_date >= start_date, "end_date must be greater than or equal to the start_date")
+
+local num_months = (eyear * 12 + emonth) - (syear * 12 + smonth)
+
+
+local function partition_list()
+    local fhs = {}
+    for i=1, partitions do
+        fhs[i] = assert(io.open(string.format("%s.%d", list_file, i), "w"))
+    end
+
+    local cnt = 0
+    for line in io.lines(list_file) do
+        local idx = cnt % partitions + 1
+        fhs[idx]:write(line, "\n")
+        cnt = cnt + 1
+    end
+
+    for i=1, partitions do
+        fhs[i]:close()
+    end
+end
+
+
+local function dump_table(fh, t, sep)
+    for k,v in pairs(t) do
+        if type(v) == "table" then
+            fh:write(string.format("%s = {\n", k, v))
+            dump_table(fh, v, ",")
+            fh:write(string.format("}%s\n", sep))
+        else
+            fh:write(string.format("%s = [[%s]]%s\n", k, v, sep))
+        end
+    end
+end
+
+
+local function load_plugins()
+    local fhs = {}
+    for i=1, partitions do
+        local partition_file = string.format("%s.%d", list_file, i)
+        local lua_cfg = string.format("%s/input/%s%02d.cfg", sblp, service, i)
+        local fh = assert(io.open(lua_cfg, "w"))
+        fh:write(string.format("filename     = '%s'\n", input_plugin))
+        fh:write(string.format("s3_bucket    = '%s'\n", s3_bucket))
+        fh:write(string.format("s3_file_list = '%s'\n", partition_file))
+        fh:write(string.format("tmp_dir      = '%s'\n\n", tmp_dir))
+        dump_table(fh, input_plugin_cfgs, "") -- put the values in the root
+        fh:close()
+    end
+end
+
+
+local function get_listing(fh, year, month)
+    local path
+    if s3_prefix then
+        path = string.format("%s/%04d-%02d", s3_prefix, year, month)
+    else
+        path = string.format("%04d-%02d", year, month)
+    end
+
+    local cmd = string.format("aws s3 ls s3://%s/%s/ > %s", s3_bucket, path, tmp_file)
+    print(cmd)
+    local rv = os.execute(cmd)
+    if rv ~= 0 and rv ~= 256 then
+        error(string.format("error executing rv: %d cmd: %s", rv, cmd))
+    end
+
+    local tfh = assert(io.open(tmp_file))
+    for line in tfh:lines() do
+        local fn, ds = string.match(line, "^%d%d%d%d%-%d%d%-%d%d%s+%d%d:%d%d:%d%d%s+%d+%s+(.-%-(%d%d%d%d%d%d%d%d)_.+)")
+        if ds then
+            ds = os.time({year = ds:sub(1, 4), month = ds:sub(5, 6), day = ds:sub(7, 8)})
+            if fn and string.find(fn, service, 1, true) and ds >= start_date and ds <= end_date then
+                fh:write(path, "/", fn, "\n")
+            end
+        end
+    end
+    tfh:close()
+end
+
+
+function process_message()
+    local fh = assert(io.open(list_file, "w"))
+    local year = tonumber(syear)
+    local month = tonumber(smonth)
+    for i=0, num_months do
+        get_listing(fh, year, month)
+        month = month + 1
+        if month == 13 then
+            month = 1
+            year  = year + 1
+        end
+    end
+    fh:close()
+
+    os.remove(tmp_file)
+    partition_list()
+    load_plugins()
+    return 0
+end

--- a/hindsight/input/telemetry_s3_bootstrap.lua
+++ b/hindsight/input/telemetry_s3_bootstrap.lua
@@ -1,0 +1,208 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+--[[
+## Heka S3 telemetry data input plugin bootstrapper
+
+This plugin:
+
+1. retrieves a list of files from S3 matching the dimension specification
+   in `dimension_file`
+1. divides the list among the specified number of `partitions`
+1. generates the cfgs to dynamically start a new reader for each partition;
+   the specified `input_plugin` should already be installed in run/input
+1. exits when the bootstrapping is complete
+
+### Sample Configuration
+```lua
+filename            = "telemetry_s3_bootstrap.lua"
+instruction_limit   = 0
+ticker_interval     = 0
+
+input_plugin        = "telemetry_s3_snappy.lua"
+input_plugin_cfgs   = {} -- table of plugin specific config options
+tmp_dir             = "/mnt/work/tmp"
+s3_bucket           = "net-mozaws-prod-us-west-2-pipeline-data"
+s3_prefix           = "telemetry-2"
+dimension_file      = "dimensions.json"
+partitions          = 8
+```
+--]]
+
+require "io"
+require "os"
+require "string"
+require "table"
+local ts3 = require "telemetry.s3"
+
+local input_plugin      = read_config("input_plugin")
+local input_plugin_cfgs = read_config("input_plugin_cfgs") or {}
+local tmp_dir           = read_config("tmp_dir")
+local s3_bucket         = read_config("s3_bucket") or error("s3_bucket must be set")
+local s3_prefix         = read_config("s3_prefix")
+local sblp              = read_config("sandbox_load_path")
+local dim_file          = read_config("dimension_file")
+local dimensions        = ts3.validate_dimensions(dim_file)
+local dimensions_size   = #dimensions
+local partitions        = tonumber(read_config("partitions"))
+if not partitions or partitions < 1 then error("partitions must be set > 0") end
+
+local dim_name          = dim_file:match("/?([^/]+)$") -- grab the filename
+dim_name                = dim_name:match("(.+)%.") or dim_name -- strip any extension
+local list_file         = string.format("%s/%s.ls", tmp_dir, dim_name)
+local tmp_file          = string.format("%s/%s.tmp", tmp_dir, dim_name)
+local LINE_MATCH        = "^%d%d%d%d%-%d%d%-%d%d%s+%d%d:%d%d:%d%d%s+%d+%s+(.+)"
+
+
+local function partition_list()
+    local fhs = {}
+    for i=1, partitions do
+        fhs[i] = assert(io.open(string.format("%s.%d", list_file, i), "w"))
+    end
+
+    local cnt = 0
+    for line in io.lines(list_file) do
+        local idx = cnt % partitions + 1
+        fhs[idx]:write(line, "\n")
+        cnt = cnt + 1
+    end
+
+    for i=1, partitions do
+        fhs[i]:close()
+    end
+end
+
+
+local function dump_table(fh, t, sep)
+    for k,v in pairs(t) do
+        if type(v) == "table" then
+            fh:write(string.format("%s = {\n", k, v))
+            dump_table(fh, v, ",")
+            fh:write(string.format("}%s\n", sep))
+        else
+            fh:write(string.format("%s = [[%s]]%s\n", k, v, sep))
+        end
+    end
+end
+
+
+local function load_plugins()
+    local fhs = {}
+    for i=1, partitions do
+        local partition_file = string.format("%s.%d", list_file, i)
+        local lua_cfg = string.format("%s/input/%s%02d.cfg", sblp, dim_name, i)
+        local fh = assert(io.open(lua_cfg, "w"))
+        fh:write(string.format("filename     = '%s'\n", input_plugin))
+        fh:write(string.format("s3_bucket    = '%s'\n", s3_bucket))
+        fh:write(string.format("s3_file_list = '%s'\n", partition_file))
+        fh:write(string.format("tmp_dir      = '%s'\n\n", tmp_dir))
+        dump_table(fh, input_plugin_cfgs, "") -- put the values in the root
+        fh:close()
+    end
+end
+
+
+function process_message()
+    local fh = assert(io.open(list_file, "w"))
+    build_path(fh, {}, 1)
+    fh:close()
+
+    os.remove(tmp_file)
+    partition_list()
+    load_plugins()
+    return 0
+end
+
+
+function build_path(fh, prefix, level)
+    if level > dimensions_size then
+        get_listing(fh, prefix, level)
+        return
+    end
+
+    local d = dimensions[level]
+    if d.matcher_type == "wildcard" or d.matcher_type == "minmax" then
+        get_listing(fh, prefix, level)
+    elseif d.matcher_type == "string" then
+        prefix[#prefix + 1] = d.allowed_values
+        build_path(fh, prefix, level + 1)
+        table.remove(prefix)
+    elseif d.matcher_type == "list" then
+        for i, v in ipairs(d.allowed_values) do
+            prefix[#prefix + 1] = v
+            build_path(fh, prefix, level + 1)
+            table.remove(prefix)
+        end
+    end
+end
+
+
+function get_listing(fh, prefix, level)
+    local is_recursive  = dimensions[level] and dimensions[level].matcher_type == "wildcard"
+    local path          = table.concat(prefix, "/")
+    local cmd
+    if s3_prefix then
+        cmd = string.format("aws s3 ls %s s3://%s/%s/%s/ > %s",
+                            is_recursive and "--recursive" or "",
+                            s3_bucket, s3_prefix, path, tmp_file)
+    else
+        cmd = string.format("aws s3 ls %s s3://%s/%s/ > %s",
+                            is_recursive and "--recursive" or "",
+                            s3_bucket, path, tmp_file)
+    end
+
+    print(cmd)
+    local rv = os.execute(cmd)
+    if rv ~= 0 and rv ~= 256 then
+        error(string.format("error executing rv: %d cmd: %s", rv, cmd))
+    end
+
+    local tfh = assert(io.open(tmp_file))
+    if is_recursive then -- get the entire set of files in the tree
+        for line in tfh:lines() do
+            local fn = string.match(line, LINE_MATCH)
+            if fn then
+                local cnt = 0
+                local keep = true
+                for dim in string.gmatch(fn, "[^/]+") do
+                    if cnt > level then
+                        for i=cnt, dimensions_size do
+                            if not dimensions[cnt].matcher(dim) then
+                                keep = false
+                                break
+                            end
+                        end
+                    end
+                    if not keep then break end
+                    cnt = cnt + 1
+                end
+                if keep then fh:write(fn, "\n") end
+            end
+        end
+    elseif level > dimensions_size then -- get the files in the last prefix
+        for line in tfh:lines() do
+            local fn = string.match(line, LINE_MATCH)
+            if fn then
+                if s3_prefix then
+                    fh:write(s3_prefix, "/", path, "/", fn, "\n")
+                else
+                    fh:write(path, "/", fn, "\n")
+                end
+            end
+        end
+    else -- match prefixes
+        local matcher = dimensions[level].matcher
+        for line in tfh:lines() do
+            local pre = line:match("PRE%s+([^/]+)/")
+            if pre then
+                 if matcher(pre) then
+                    prefix[#prefix + 1] = pre
+                    build_path(prefix, level + 1)
+                    table.remove(prefix)
+                end
+            end
+        end
+    end
+    tfh:close()
+end

--- a/hindsight/input/telemetry_s3_snappy.lua
+++ b/hindsight/input/telemetry_s3_snappy.lua
@@ -1,0 +1,127 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+--[[
+## Reader for the S3 telemetry files that are Heka framed, snappy encoded
+messsages
+
+Retrieves/reads each file from the `s3_file_list`. The primary use of this
+plugin is to feed the transformed/validated data into analysis plugins. Once
+the snappy ugliness is removed (Bugzilla #1250218) the generalized 'heka_s3.lua'
+input can be used instead.
+
+
+### Sample Configuration
+```lua
+filename        = "telemetry_s3_snappy.lua"
+s3_bucket       = "net-mozaws-prod-us-west-2-pipeline-data"
+s3_file_list    = "telemetry_dims.ls.1"
+tmp_dir         = "/mnt/work/tmp"
+```
+--]]
+
+require "io"
+require "heka_stream_reader"
+require "os"
+require "snappy"
+require "string"
+
+local tmp_dir       = read_config("tmp_dir")
+local s3_bucket     = read_config("s3_bucket") or error("s3_bucket must be set")
+local logger        = read_config("Logger")
+local s3_file_list  = assert(io.open(read_config("s3_file_list")))
+
+
+local function snappy_decode(msgbytes)
+    local ok, uc = pcall(snappy.uncompress, msgbytes)
+    if ok then
+        return uc
+    end
+    return msgbytes
+end
+
+
+local function process_snappy_ugliness(hsr, dhsr, fh)
+    local found, consumed, read
+    repeat
+        repeat
+            found, consumed, read = hsr:find_message(fh, false) -- don't protobuf decode
+            if found then
+                local pbm = snappy_decode(hsr:read_message("raw"))
+                local ok = pcall(dhsr.decode_message, dhsr, pbm)
+                if ok then
+                    inject_message(dhsr)
+                end
+            end
+        until not found
+    until read == 0
+end
+
+
+local function process_file(hsr, fh)
+    local found, consumed, read
+    repeat
+        repeat
+            found, consumed, read = hsr:find_message(fh)
+            if found then
+                inject_message(hsr)
+            end
+        until not found
+    until read == 0
+end
+
+
+local function execute_cmd(cmd, retries)
+    local rv = 1
+    for i=1, retries do
+        rv = os.execute(cmd)
+        if rv == 0 then
+            break
+        end
+    end
+    return rv
+end
+
+
+function process_message()
+    local hsr  = heka_stream_reader.new("s3")
+    local dhsr = heka_stream_reader.new("snappy")
+
+    for fn in s3_file_list:lines() do
+        local cmd
+        local tfn = string.format("%s/%s", tmp_dir, logger)
+        local ext = fn:match("%.([^.]-)$")
+        if ext == "zst" then
+            cmd = string.format("aws s3 cp s3://%s/%s - | zstd -d -c - > %s", s3_bucket, fn, tfn)
+        elseif ext == "gz" then
+            cmd = string.format("aws s3 cp s3://%s/%s - | gzip -d -c - > %s", s3_bucket, fn, tfn)
+        else
+            ext = nil
+            cmd = string.format("aws s3 cp s3://%s/%s %s", s3_bucket, fn, tfn)
+        end
+
+        print("processing", cmd)
+        local rv = execute_cmd(cmd, 3)
+        if rv == 0 then
+            local fh, err = io.open(tfn)
+            if not fh then
+                print("failed to open", tfn)
+                return 0
+            end
+            if ext then
+                process_file(hsr, fh)
+            else
+                process_snappy_ugliness(hsr, dhsr, fh)
+            end
+            fh:close()
+        else
+            print("failed to execute rv:", rv, " cmd:", cmd)
+        end
+    end
+    return 0
+end

--- a/hindsight/io_modules/telemetry/s3.lua
+++ b/hindsight/io_modules/telemetry/s3.lua
@@ -1,0 +1,152 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+--[[
+## Telemetry S3 path dimension specification parser/validator
+
+Note: This specification may be expanded, if needed, to include:
+* field/array index support
+* patterns instead of exact matches
+* a matcher on filename (i.e. use cases outside of Mozilla telemetry)
+
+### Sample Dimension Specification
+```json
+  {
+    "version": 1,
+    "dimensions": [
+      {"header_name": "Type", "allowed_values": "telemetry"},
+
+      {"field_name": "submissionDate", "allowed_values": {"min": "20140120", "max": "20140125"}},
+      {"field_name": "sourceName", "allowed_values": "*"},
+      {"field_name": "sourceVersion", "allowed_values": "*"},
+      {"field_name": "reason", "allowed_values": ["idle-daily", "saved-session"]},
+      {"field_name": "appName", "allowed_values": ["Firefox", "Fennec"]},
+      {"field_name": "appUpdateChannel", "allowed_values": ["nightly", "beta", "release"]},
+      {"field_name": "appVersion", "allowed_values": "*"}
+    ]
+  }
+```
+
+### API
+
+#### validate_dimensions(filename)
+
+Loads and validates the dimension specification from disk.
+
+*Arguments*
+* filename (string) - name of the file containing the JSON dimension specification
+
+*Return*
+* table - contains the parsed/validated dimensions array with the following modifications
+  * `header_name` is re-mapped to `field_name` and and field_name values are expanded to 'Fields[`name`]'
+  * `matcher_type` string is added (wildcard|string|list|minmax)
+  * `matcher` function is added (returns true if a value matches the specification)
+
+#### sanitize_dimension(value)
+
+Returns a string suitable for use as an S3 path component.
+
+*Arguments*
+* value (string, number, bool) - converted to a string, sanitized and returned
+
+*Return*
+* string - nil if the value was not convertible to a string
+--]]
+
+-- Imports
+local assert    = assert
+local error     = error
+local ipairs    = ipairs
+local tostring  = tostring
+local type      = type
+
+local cjson     = require "cjson"
+local io        = require "io"
+local string    = require "string"
+
+local M = {}
+setfenv(1, M) -- Remove external access to contain everything in the module
+
+
+local function is_in_list(v, av)
+    for i, j in ipairs(av) do
+        if v == j then return true end
+    end
+    return false
+end
+
+
+local function is_in_range(v, min, max)
+    if min and v < min then return false end
+    if max and v > max then return false end
+    return true
+end
+
+
+function validate_dimensions(fn)
+    local fh = assert(io.open(fn))
+    local json = fh:read("*a")
+    fh:close()
+
+    local df = cjson.decode(json)
+    for i,d in ipairs(df.dimensions) do
+        local name
+        if d.header_name then
+            name = d.header_name
+            if name ~= "Uuid" and name ~= "Timestamp" and name ~= "Type"
+            and name ~= "Logger" and name ~= "Severity" and name ~= "Payload"
+            and name ~= "EnvVersion" and name ~= "Pid" and name ~= "Hostname" then
+                error("invalid header name " .. name)
+            end
+            d.header_name = nil
+        else
+            name = string.format("Fields[%s]", d.field_name)
+        end
+        d.field_name = name
+        local av = d.allowed_values
+        if type(av) == "string" then
+            if av == "*" then
+                d.matcher = function (v) return true end
+                d.matcher_type = "wildcard"
+            else
+                av = sanitize_dimension(av)
+                d.matcher = function (v) return v == av end
+                d.matcher_type = "string"
+            end
+        elseif type(av) == "table" then
+            if av[1] ~= nil then
+                for m,n in ipairs(av) do
+                    if type(n) ~= "string" then
+                        error(string.format("field '$s' allowed_values array must contain only strings", name))
+                    end
+                    av[m] = sanitize_dimension(n)
+                end
+                d.matcher = function (v) return is_in_list(v, av) end
+                d.matcher_type = "list"
+            else
+                if not av.min and not av.max then
+                    error(string.format("field '%s' allowed_values range must have a 'min' or 'max'", name))
+                end
+                if av.min and type(av.min) ~= "string"
+                or av.max and type(av.max) ~= "string" then
+                    error(string.format("field '%s' allowed_values range min/max must be a string", name))
+                end
+                d.matcher = function (v) return is_in_range(v, av.min, av.max) end
+                d.matcher_type = "minmax"
+            end
+        else
+            error(string.format("field '%s' allowed_values invalid type: %s", type(av)))
+        end
+    end
+    return df.dimensions
+end
+
+
+function sanitize_dimension(d)
+    if d ~= nil then
+        return string.gsub(tostring(d), "[^a-zA-Z0-9_.]", "_")
+    end
+end
+
+return M

--- a/hindsight/output/telemetry_s3.lua
+++ b/hindsight/output/telemetry_s3.lua
@@ -1,0 +1,199 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+--[[
+## Heka Protobuf Message S3 Output Partitioner
+
+Batches message data into Heka protobuf stream files based on the specified path
+dimensions and copies them to S3 when they reach the maximum size or maximum
+age.
+
+#### Sample Configuration
+
+```lua
+filename        = "telemetry_s3.lua"
+message_matcher = "Type == 'telemetry'"
+ticker_interval = 60
+
+-- see the mozilla.telemetry.dimensions module
+dimension_file  = "foobar.json"
+
+-- directory location to store the intermediate output files
+batch_path       = "/var/tmp/foobar"
+
+-- Specifies how many data files to keep open at once. If there are more
+-- "current" files than this, the least-recently used file will be closed
+-- and then re-opened if more messages arrive before it is copied to S3. The
+-- default is 1000. A value of 0 means no maximum.
+max_file_handles    = 1000
+
+-- Specifies how much data (in bytes) can be written to a single file before
+-- it is copied to s3 (default 500MB)
+max_file_size       = 1024 * 1024 * 500
+
+-- Specifies how long (in seconds) to wait before it is copied to s3
+-- (default 1 hour).  Idle files are only checked every ticker_interval seconds.
+max_file_age        = 60 * 60
+
+-- Specifies that all local files will be copied S3 before exiting (default false).
+flush_on_shutdown = true
+preserve_data       = not flush_on_shutdown -- should always be the inverse of flush_on_shutdown
+
+s3_path             = "s3://foo"
+
+compression         = "zst"
+```
+--]]
+
+require "cjson"
+require "io"
+require "os"
+require "string"
+require "table"
+local ts3 = require "telemetry.s3"
+
+files               = {}
+local fh_cnt        = 0
+local time_t        = 0
+local buffer_cnt    = 0
+
+local hostname              = read_config("Hostname")
+local batch_path            = read_config("batch_path") or error("batch_path must be specified")
+local s3_path               = read_config("s3_path") or error("s3_path must be specified")
+local max_file_handles      = read_config("max_file_handles") or 1000
+local max_file_size         = read_config("max_file_size") or 1024 * 1024 * 500
+local max_file_age          = read_config("max_file_age") or 60 * 60
+local flush_on_shutdown     = read_config("flush_on_shutdown")
+local compression           = read_config("compression")
+if compression and compression ~= "zst" and compression ~= "gz" then
+    error("compression must be nil, zst or gz")
+end
+
+
+local function get_fqfn(path)
+    return string.format("%s/%s", batch_path, path)
+end
+
+
+local function close_fh(entry)
+    if not entry[2] then return end
+    entry[2]:close()
+    entry[2] = nil
+    fh_cnt = fh_cnt - 1
+end
+
+
+local function copy_file(path, entry)
+    close_fh(entry)
+    local t = os.time()
+    local cmd
+    if t == time_t then
+        buffer_cnt = buffer_cnt + 1
+    else
+        time_t = t
+        buffer_cnt = 0
+    end
+
+    local src  = get_fqfn(path)
+    local dim_path = string.gsub(path, "+", "/")
+    if compression == "zst" then
+        cmd = string.format("zstd -c %s | aws s3 cp - %s/%s/%d_%d_%s.%s", src,
+                            s3_path, dim_path, time_t, buffer_cnt, hostname, compression)
+    elseif compression == "gz" then
+        cmd = string.format("gzip -c %s | aws s3 cp - %s/%s/%d_%d_%s.%s", src,
+                            s3_path, dim_path, time_t, buffer_cnt, hostname, compression)
+    else
+        cmd = string.format("aws s3 cp %s %s/%s/%d_%d_%s", src,
+                            s3_path, dim_path, time_t, buffer_cnt, hostname)
+    end
+
+    print(cmd)
+    local ret = os.execute(cmd)
+    if ret ~= 0 then
+        return string.format("ret: %d, cmd: %s", ret, cmd)
+    end
+    files[path] = nil
+
+    local ok, err = os.remove(src);
+    if not ok then
+        return string.format("os.remove('%s') failed: %s", path, err)
+    end
+end
+
+
+local function get_entry(path)
+    local ct = os.time()
+    local t = files[path]
+    if not t then
+        t = {ct, nil} -- last active, file handle
+        files[path] = t
+    else
+        t[1] = ct
+    end
+
+    if not t[2] then
+        if max_file_handles ~= 0 then
+            if fh_cnt >= max_file_handles then
+                local oldest = ct + 60
+                local entry
+                for k,v in pairs(files) do -- if we max out file handles a lot we will want to make this more efficient
+                    local et = v[1]
+                    if v[2] and et < oldest then
+                        entry = v
+                        oldest = et
+                    end
+                end
+                if entry then close_fh(entry) end
+            end
+        end
+        t[2] = assert(io.open(get_fqfn(path), "a"))
+        fh_cnt = fh_cnt + 1
+    end
+    return t
+end
+
+local dimensions = ts3.validate_dimensions(read_config("dimension_file"))
+
+function process_message()
+    local dims = {}
+    for i,d in ipairs(dimensions) do
+        local v = ts3.sanitize_dimension(read_message(d.field_name))
+        if v then
+            if d.matcher(v) then
+                dims[i] = v
+            else
+                dims[i] = "OTHER"
+            end
+        else
+            dims[i] = "UNKNOWN"
+        end
+    end
+    local path = table.concat(dims, "+") -- the plus will be converted to a path separator '/' on copy
+    local entry = get_entry(path)
+    local fh = entry[2]
+    fh:write(read_message("framed"))
+    local size = fh:seek()
+    if size >= max_file_size then
+        local err = copy_file(path, entry)
+        if err then print(err) end
+    end
+    return 0
+end
+
+
+function timer_event(ns, shutdown)
+    local err
+    local ct = os.time()
+    for k,v in pairs(files) do
+        if (shutdown and flush_on_shutdown) or (ct - v[1] >= max_file_age) then
+            local e = copy_file(k, v)
+            if e then err = e end
+        elseif shutdown then
+            close_fh(v)
+        end
+    end
+    if shutdown and flush_on_shutdown and err then
+        error(string.format("flush on shutdown failed, last error: %s", err))
+    end
+end


### PR DESCRIPTION
For data input
- Replaces the heka-s3(list|cat) tools and the s3splitfile_input
- Supports full file compression (zst, gz, uncompressed)
- Bootstrapping support to ease configuration (for both telemetry and server logs)
  - Automatically partitions the work across the specified number of plugins
  - Dynamically creates the configurations and launches the inputs

For data output
- Replaces the s3splitfile_output
- Supports full file compression (zst, gz, uncompressed)
