### PR TITLE
Bug 1302050 - make mobile_clients job idempotent

### DIFF
--- a/reports/mobile_clients/mobile-clients.ipynb
+++ b/reports/mobile_clients/mobile-clients.ipynb
@@ -189,7 +189,7 @@
     "        if channel == \"release\":\n",
     "            coalesce = 4\n",
     "        grouped = sqlContext.createDataFrame(transformed, schema)\n",
-    "        grouped.coalesce(coalesce).write.parquet(s3_output)\n",
+    "        grouped.coalesce(coalesce).write.mode('overwrite').parquet(s3_output)\n",
     "\n",
     "    day += dt.timedelta(1)\n"
    ]


### PR DESCRIPTION
Using mode=overwrite makes the job repeatable. See [the spark docs](https://spark.apache.org/docs/2.0.0/sql-programming-guide.html#save-modes) for a list of available modes.
