### PR TITLE
Add push users ER re:dash query

### DIFF
--- a/reports/push_notifications/push_user_er.sql
+++ b/reports/push_notifications/push_user_er.sql
@@ -11,7 +11,7 @@ WITH sample AS (
 push_accepters AS (
    SELECT DISTINCT client_id,
                    normalized_submission_date AS eligibility_start,
-                   normalized_submission_date + interval '30' DAY AS eligibility_end
+                   CASE WHEN ((normalized_submission_date + interval '30' DAY) > CURRENT_DATE) THEN CURRENT_DATE ELSE (normalized_submission_date + interval '30' DAY) END AS eligibility_end
    FROM sample
    WHERE push_acceptance > 0
 ),
@@ -26,38 +26,35 @@ combined_push_users AS (
 ),
 all_dau AS (
    SELECT DISTINCT client_id,
-                   normalized_submission_date AS activity_date
+                   normalized_submission_date
    FROM sample
 ),
 push_dau AS (
-  -- Presto can't do RANGE window functions nor can it do count distinct in a window, so the array_agg here and in push_mau is a workaround hack.
-  -- I feel dirty.
   SELECT count(DISTINCT p.client_id) AS dau,
-         array_agg(p.client_id) AS client_ids,
-         activity_date
+         merge(hll_create(p.client_id, 15)) AS hll,
+         normalized_submission_date
   FROM all_dau d
   INNER JOIN combined_push_users p ON d.client_id = p.client_id
-  WHERE activity_date BETWEEN eligibility_start AND eligibility_end
+  WHERE normalized_submission_date BETWEEN eligibility_start AND eligibility_end
   GROUP BY 3
 ),
 push_mau AS (
-  -- I'm sorry.
-  SELECT cardinality(array_distinct(flatten(array_agg(client_ids) over (ORDER BY activity_date ROWS BETWEEN 27 PRECEDING AND 0 FOLLOWING)))) AS mau,
-         activity_date
+  SELECT cardinality(merge(hll) over (ORDER BY normalized_submission_date ROWS BETWEEN 27 PRECEDING AND 0 FOLLOWING)) as mau,
+         normalized_submission_date
    FROM push_dau
 ),
 smoothed_dau AS (
-   SELECT activity_date,
-          avg(dau) OVER (ORDER BY activity_date ROWS BETWEEN 6 PRECEDING AND 0 FOLLOWING) AS smoothed_dau
+   SELECT normalized_submission_date,
+          avg(dau) OVER (ORDER BY normalized_submission_date ROWS BETWEEN 6 PRECEDING AND 0 FOLLOWING) AS smoothed_dau
    FROM push_dau
 )
 SELECT mau * 100 AS mau,
        dau * 100 AS dau,
        smoothed_dau * 100 AS smoothed_dau,
-       m.activity_date,
+       m.normalized_submission_date,
        smoothed_dau/mau AS ER
 FROM push_mau m
-JOIN push_dau d ON m.activity_date=d.activity_date
-JOIN smoothed_dau s ON m.activity_date=s.activity_date
-WHERE m.activity_date > (CURRENT_DATE - interval '6' MONTH + interval '30' DAY)
-ORDER BY m.activity_date
+JOIN push_dau d ON m.normalized_submission_date=d.normalized_submission_date
+JOIN smoothed_dau s ON m.normalized_submission_date=s.normalized_submission_date
+WHERE m.normalized_submission_date > (CURRENT_DATE - interval '6' MONTH + interval '30' DAY)
+ORDER BY m.normalized_submission_date

--- a/reports/push_notifications/push_user_er.sql
+++ b/reports/push_notifications/push_user_er.sql
@@ -1,0 +1,63 @@
+WITH sample AS (
+   SELECT client_id,
+          date_parse(submission_date_s3, '%Y%m%d') as normalized_submission_date,
+          popup_notification_stats['web-notifications'].action_1 AS push_acceptance,
+          web_notification_shown
+   FROM main_summary
+   WHERE submission_date_s3 > date_format(CURRENT_DATE - interval '6' MONTH, '%Y%m%d')
+     AND submission_date_s3 < date_format(CURRENT_DATE, '%Y%m%d')
+     AND sample_id='42'
+),
+push_accepters AS (
+   SELECT DISTINCT client_id,
+                   normalized_submission_date AS eligibility_start,
+                   normalized_submission_date + interval '30' DAY AS eligibility_end
+   FROM sample
+   WHERE push_acceptance > 0
+),
+combined_push_users AS (
+   SELECT DISTINCT p.client_id,
+                   eligibility_start,
+                   eligibility_end
+   FROM sample s
+   INNER JOIN push_accepters p ON s.client_id=p.client_id
+   WHERE normalized_submission_date BETWEEN eligibility_start AND eligibility_end
+   AND web_notification_shown > 0
+),
+all_dau AS (
+   SELECT DISTINCT client_id,
+                   normalized_submission_date AS activity_date
+   FROM sample
+),
+push_dau AS (
+  -- Presto can't do RANGE window functions nor can it do count distinct in a window, so the array_agg here and in push_mau is a workaround hack.
+  -- I feel dirty.
+  SELECT count(DISTINCT p.client_id) AS dau,
+         array_agg(p.client_id) AS client_ids,
+         activity_date
+  FROM all_dau d
+  INNER JOIN combined_push_users p ON d.client_id = p.client_id
+  WHERE activity_date BETWEEN eligibility_start AND eligibility_end
+  GROUP BY 3
+),
+push_mau AS (
+  -- I'm sorry.
+  SELECT cardinality(array_distinct(flatten(array_agg(client_ids) over (ORDER BY activity_date ROWS BETWEEN 27 PRECEDING AND 0 FOLLOWING)))) AS mau,
+         activity_date
+   FROM push_dau
+),
+smoothed_dau AS (
+   SELECT activity_date,
+          avg(dau) OVER (ORDER BY activity_date ROWS BETWEEN 6 PRECEDING AND 0 FOLLOWING) AS smoothed_dau
+   FROM push_dau
+)
+SELECT mau * 100 AS mau,
+       dau * 100 AS dau,
+       smoothed_dau * 100 AS smoothed_dau,
+       m.activity_date,
+       smoothed_dau/mau AS ER
+FROM push_mau m
+JOIN push_dau d ON m.activity_date=d.activity_date
+JOIN smoothed_dau s ON m.activity_date=s.activity_date
+WHERE m.activity_date > (CURRENT_DATE - interval '6' MONTH + interval '30' DAY)
+ORDER BY m.activity_date


### PR DESCRIPTION
Moving the review from [this gist](https://gist.github.com/vitillo/73851c25ef33987e24bbc175808fc3d4). My last comments were:

> Re: submission_date vs activity_date, is there a standard that's usually used for ER? Wasn't sure what best practice was for this given clients' clock skew. I figured if I used Submission Date it'd just even out (i.e. the number of clients submitting on a different date than their activity date would be consistent over time.)
> Re: using longitudinal, not sure if you caught the discussion in IRC but my understanding of the longitudinal dataset is that it's not partitioned by date, and doing any date-based manipulation looks like it'd be difficult (even looking up the date that someone had a non-zero web_notification_shown looks like it'd require jumping through a lot of hoops)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-services/data-pipeline/225)

<!-- Reviewable:end -->
