### PR TITLE
Update Orphaning - Use correct latest version

### DIFF
--- a/reports/update-orphaning/Update orphaning analysis using longitudinal dataset.ipynb
+++ b/reports/update-orphaning/Update orphaning analysis using longitudinal dataset.ipynb
@@ -80,12 +80,10 @@
    },
    "outputs": [],
    "source": [
+    "# Uncomment the next line and adjust |today_env_str| as necessary to run manually\n",
+    "#today_env_str = \"20161105\"\n",
     "today_env_str = environ.get(\"date\", None)\n",
     "\n",
-    "# Uncomment the next two lines and adjust |today| as necessary to run manually\n",
-    "#today = dt.date.today()\n",
-    "#today_env_str = today.strftime(\"%Y%m%d\")\n",
-    "# Comment out the next two lines to run manually\n",
     "assert (today_env_str is not None), \"The date environment parameter is missing.\"\n",
     "today = dt.datetime.strptime(today_env_str, \"%Y%m%d\").date()\n",
     "\n",
@@ -100,6 +98,7 @@
     "min_range = last_wednesday - dt.timedelta(days=17)\n",
     "report_date_str = last_wednesday.strftime(\"%Y%m%d\")\n",
     "min_range_str = min_range.strftime(\"%Y%m%d\")\n",
+    "min_range_dash_str = min_range.strftime(\"%Y-%m-%d\")\n",
     "list([last_wednesday, min_range_str, report_date_str])"
    ]
   },
@@ -161,8 +160,7 @@
     "                                    \"update_check_code_notify\",\n",
     "                                    \"update_check_no_update_notify\",\n",
     "                                    \"build.version\",\n",
-    "                                    \"settings.update.enabled\")\n",
-    "%time data_subset.count()"
+    "                                    \"settings.update.enabled\")"
    ]
   },
   {
@@ -190,16 +188,14 @@
     "    except TypeError:\n",
     "        return False\n",
     "\n",
-    "date_filtered = data_subset.rdd.filter(start_date_filter).cache()\n",
-    "\n",
-    "%time date_filtered.count()"
+    "date_filtered = data_subset.rdd.filter(start_date_filter)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Analyze the data to determine the number of users on a current version of Firefox vs. a version that's out of date. A \"user on a current version\" is defined as being either on the version found in the version.txt file on hg.mozilla.org, or the two versions just prior to it. Versions prior to FF 42 are ignored since unified telemetry was not turned on by default on earlier versions."
+    "Analyze the data to determine the number of users on a current version of Firefox vs. a version that's out of date. A \"user on a current version\" is defined as being either on the latest version as of the beginning of the 7 day range, according to the firefox_history_major_releases.json file on product-details.mozilla.org, or the two versions just prior to it. Versions prior to FF 42 are ignored since unified telemetry was not turned on by default on earlier versions."
    ]
   },
   {
@@ -211,8 +207,19 @@
    },
    "outputs": [],
    "source": [
-    "latest_version = urllib2.urlopen(\"http://hg.mozilla.org/releases/mozilla-\" + channel_to_process + \"/raw-file/tip/browser/config/version.txt\").read()\n",
-    "latest_version = int(latest_version.split(\".\")[0])\n",
+    "def latest_version_on_date(date, major_releases):\n",
+    "    latest_date, latest_version = u\"1900-01-01\", 0\n",
+    "    for version, release_date in major_releases.iteritems():\n",
+    "        version_int = int(version.split(\".\")[0])\n",
+    "        if release_date <= date and release_date >= latest_date and version_int >= latest_version:\n",
+    "            latest_date = release_date\n",
+    "            latest_version = version_int\n",
+    "            \n",
+    "    return latest_version\n",
+    "    \n",
+    "major_releases_json = urllib2.urlopen(\"https://product-details.mozilla.org/1.0/firefox_history_major_releases.json\").read()\n",
+    "major_releases = json.loads(major_releases_json)\n",
+    "latest_version = latest_version_on_date(min_range_dash_str, major_releases)\n",
     "\n",
     "def status_mapper(d):\n",
     "    try:\n",
@@ -457,8 +464,9 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python2"
   },
@@ -472,7 +480,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
needs-review: @vitillo 

Look up the major release version history on
product-details.mozilla.org to find what version was current as of
the beginning of the week under consideration, instead of pulling
version.txt from hg which can be updated ahead of time.

This also allows the job to be safely re-run for old dates.

Also removes some debugging counting and output.

I'd appreciate if @matt-howell (IRC mhowell) could take a look as well.

-Adam Gashlin (IRC agashlin)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-services/data-pipeline/235)
<!-- Reviewable:end -->
