### PR TITLE
Fixed atmo job getting-crash-stats-for-OOM-data-to-S3 by...

### DIFF
--- a/reports/crash_stats_oom/getting-crash-stats-for-OOM-data-to-S3.ipynb
+++ b/reports/crash_stats_oom/getting-crash-stats-for-OOM-data-to-S3.ipynb
@@ -157,7 +157,6 @@
     "    param_data = {}\n",
     "    param_data['release_channel'] = \"beta\"\n",
     "    param_data['process_type'] = \"content\"\n",
-    "    # param_data['_facets'] = \"signature\"\n",
     "    param_data['_results_number'] = str(per_page_default)\n",
     "    param_data['date'] = [\">=\" + start_date, \"<\" + stop_date]\n",
     "    param_data['_columns'] = [\"date\",\n",

--- a/reports/crash_stats_oom/getting-crash-stats-for-OOM-data-to-S3.ipynb
+++ b/reports/crash_stats_oom/getting-crash-stats-for-OOM-data-to-S3.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "collapsed": true
    },
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {
     "collapsed": true
    },
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "metadata": {
     "collapsed": true
    },
@@ -152,12 +152,12 @@
     "        'Content-Type': 'application/json; charset=UTF-8'\n",
     "    }\n",
     "    target = 'https://crash-stats.mozilla.com/api/SuperSearch/'\n",
-    "    per_page_default = 100\n",
+    "    per_page_default = 500\n",
     "\n",
     "    param_data = {}\n",
     "    param_data['release_channel'] = \"beta\"\n",
     "    param_data['process_type'] = \"content\"\n",
-    "    param_data['_facets'] = \"signature\"\n",
+    "    # param_data['_facets'] = \"signature\"\n",
     "    param_data['_results_number'] = str(per_page_default)\n",
     "    param_data['date'] = [\">=\" + start_date, \"<\" + stop_date]\n",
     "    param_data['_columns'] = [\"date\",\n",
@@ -193,7 +193,7 @@
     "        # Determine the number of pages (only on first page request)\n",
     "        if (reqs == 0):\n",
     "            total_results = data[\"total\"]\n",
-    "            total_pages = (int(math.ceil(total_results/100.0)) * 100) / 100\n",
+    "            total_pages = (int(math.ceil(total_results/float(per_page_default))) * per_page_default) / per_page_default\n",
     "            if (total_pages > pages):\n",
     "                pages = total_pages\n",
     "        # Grab the 'hits' into lists\n",
@@ -243,48 +243,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "root\n",
-      " |-- uuid: string (nullable = false)\n",
-      " |-- date: timestamp (nullable = false)\n",
-      " |-- signature: string (nullable = false)\n",
-      " |-- platform: string (nullable = true)\n",
-      " |-- contains_memory_report: boolean (nullable = true)\n",
-      " |-- oom_allocation_size: long (nullable = true)\n",
-      " |-- system_memory_use_percentage: integer (nullable = true)\n",
-      " |-- total_virtual_memory: long (nullable = true)\n",
-      " |-- available_virtual_memory: long (nullable = true)\n",
-      " |-- total_page_file: long (nullable = true)\n",
-      " |-- available_page_file: long (nullable = true)\n",
-      " |-- total_physical_memory: long (nullable = true)\n",
-      " |-- available_physical_memory: long (nullable = true)\n",
-      " |-- largest_free_vm_block: string (nullable = true)\n",
-      " |-- largest_free_vm_block_int: long (nullable = true)\n",
-      " |-- tiny_block_size: long (nullable = true)\n",
-      " |-- write_combine_size: long (nullable = true)\n",
-      " |-- shutdown_progress: string (nullable = true)\n",
-      " |-- ipc_channel_error: string (nullable = true)\n",
-      " |-- user_comments: string (nullable = true)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "get_crashstats_by_day(date_format, DEBUG, target_date)"
    ]
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python2"
   },
@@ -298,7 +270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
increasing per_page_results to 500 to handle rate limit, removed unused facet, replaced magic numbers with per_page_default. I used this to backfill data from yesterday, as if this were the regularly scheduled version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-services/data-pipeline/247)
<!-- Reviewable:end -->
