### PR TITLE
Updated getting-crash-stats-for-OOM-data-to-S3.ipynb to use token...

### DIFF
--- a/reports/crash_stats_oom/getting-crash-stats-for-OOM-data-to-S3.ipynb
+++ b/reports/crash_stats_oom/getting-crash-stats-for-OOM-data-to-S3.ipynb
@@ -157,7 +157,6 @@
     "    param_data = {}\n",
     "    param_data['release_channel'] = \"beta\"\n",
     "    param_data['process_type'] = \"content\"\n",
-    "    # param_data['_facets'] = \"signature\"\n",
     "    param_data['_results_number'] = str(per_page_default)\n",
     "    param_data['date'] = [\">=\" + start_date, \"<\" + stop_date]\n",
     "    param_data['_columns'] = [\"date\",\n",

--- a/reports/crash_stats_oom/getting-crash-stats-for-OOM-data-to-S3.ipynb
+++ b/reports/crash_stats_oom/getting-crash-stats-for-OOM-data-to-S3.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -66,17 +66,13 @@
     "    key = \"{}/{}\".format(s3path, filename)\n",
     "\n",
     "    s3 = boto3.resource('s3')\n",
+    "    obj = s3.Object(data_bucket, key)\n",
     "\n",
     "    try:\n",
-    "        obj = s3.Object(data_bucket, key)\n",
-    "    except botocore.exceptions.ClientError as e:\n",
-    "        # If the file wasn't there, that's ok. Otherwise, abort!\n",
-    "        if e.response['Error']['Code'] != \"404\":\n",
-    "            raise e\n",
-    "        else:\n",
-    "            print \"Did not find an existing file at '{}'\".format(key)\n",
-    "\n",
-    "    token = obj.get()['Body'].read()\n",
+    "        token = obj.get()['Body'].read()\n",
+    "    except:\n",
+    "        token = None\n",
+    "    \n",
     "    return token\n"
    ]
   },
@@ -89,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -106,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -153,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -170,13 +166,15 @@
     "    stop_date = (dt.datetime.strptime(start_date, format) +\n",
     "                 dt.timedelta(days=1)).strftime(format)\n",
     "\n",
-    "    token = get_token_from_s3()\n",
-    "\n",
     "    headers = {\n",
     "        'Accept': 'application/json',\n",
-    "        'Auth-Token': token,\n",
     "        'Content-Type': 'application/json; charset=UTF-8'\n",
     "    }\n",
+    "    # Try to get the token, but if it fails try without it\n",
+    "    token = get_token_from_s3()\n",
+    "    if token:\n",
+    "        headers['Auth-Token'] = token\n",
+    "    \n",
     "    target = 'https://crash-stats.mozilla.com/api/SuperSearch/'\n",
     "    per_page_default = 500\n",
     "\n",
@@ -260,6 +258,77 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Sometimes, when re-running this manually, this is handy.\n",
+    "def count_crashstats_by_day(format, debug, specify_date=None):\n",
+    "    \"\"\" Get total crashstats data for a specified date.\n",
+    "    Will use previous day if not specified. \"\"\"\n",
+    "    if specify_date:\n",
+    "        start_date = specify_date\n",
+    "    else:\n",
+    "        start_date = (dt.datetime.now() -\n",
+    "                      dt.timedelta(days=1)).strftime(format)\n",
+    "    stop_date = (dt.datetime.strptime(start_date, format) +\n",
+    "                 dt.timedelta(days=1)).strftime(format)\n",
+    "\n",
+    "    headers = {\n",
+    "        'Accept': 'application/json',\n",
+    "        'Content-Type': 'application/json; charset=UTF-8'\n",
+    "    }\n",
+    "    # Try to get the token, but if it fails try without it\n",
+    "    token = get_token_from_s3()\n",
+    "    if token:\n",
+    "        headers['Auth-Token'] = token\n",
+    "\n",
+    "    target = 'https://crash-stats.mozilla.com/api/SuperSearch/'\n",
+    "    per_page_default = 500\n",
+    "\n",
+    "    param_data = {}\n",
+    "    param_data['release_channel'] = \"beta\"\n",
+    "    param_data['process_type'] = \"content\"\n",
+    "    param_data['_results_number'] = str(per_page_default)\n",
+    "    param_data['date'] = [\">=\" + start_date, \"<\" + stop_date]\n",
+    "    param_data['_columns'] = [\"date\",\n",
+    "                              \"uuid\",\n",
+    "                              \"signature\",\n",
+    "                              \"oom_allocation_size\",\n",
+    "                              \"platform\",\n",
+    "                              \"contains_memory_report\",\n",
+    "                              \"system_memory_use_percentage\",\n",
+    "                              \"total_virtual_memory\",\n",
+    "                              \"available_virtual_memory\",\n",
+    "                              \"total_page_file\",\n",
+    "                              \"available_page_file\",\n",
+    "                              \"total_physical_memory\",\n",
+    "                              \"available_physical_memory\",\n",
+    "                              \"largest_free_vm_block\",\n",
+    "                              \"tiny_block_size\",\n",
+    "                              \"write_combine_size\",\n",
+    "                              \"shutdown_progress\",\n",
+    "                              \"ipc_channel_error\",\n",
+    "                              \"user_comments\"]\n",
+    "\n",
+    "    reqs = 0\n",
+    "    pages = 1\n",
+    "    offset = 0\n",
+    "    all_results = []\n",
+    "\n",
+    "    # Access each page by offset and append results to the all_results list\n",
+    "    offset = reqs * per_page_default\n",
+    "    param_data['_results_offset'] = str(offset)\n",
+    "    data = get_API_data(target, param_data, headers)\n",
+    "    total_results = data[\"total\"]\n",
+    "    total_pages = (int(math.ceil(total_results/float(per_page_default))) * per_page_default) / per_page_default\n",
+    "    return total_pages"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -268,13 +337,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "get_crashstats_by_day(date_format, DEBUG)"
+    "get_crashstats_by_day(date_format, DEBUG, target_date)"
    ]
   },
   {

--- a/reports/crash_stats_oom/getting-crash-stats-for-OOM-data-to-S3.ipynb
+++ b/reports/crash_stats_oom/getting-crash-stats-for-OOM-data-to-S3.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "collapsed": true
    },
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {
     "collapsed": true
    },
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "metadata": {
     "collapsed": true
    },
@@ -152,12 +152,12 @@
     "        'Content-Type': 'application/json; charset=UTF-8'\n",
     "    }\n",
     "    target = 'https://crash-stats.mozilla.com/api/SuperSearch/'\n",
-    "    per_page_default = 100\n",
+    "    per_page_default = 500\n",
     "\n",
     "    param_data = {}\n",
     "    param_data['release_channel'] = \"beta\"\n",
     "    param_data['process_type'] = \"content\"\n",
-    "    param_data['_facets'] = \"signature\"\n",
+    "    # param_data['_facets'] = \"signature\"\n",
     "    param_data['_results_number'] = str(per_page_default)\n",
     "    param_data['date'] = [\">=\" + start_date, \"<\" + stop_date]\n",
     "    param_data['_columns'] = [\"date\",\n",
@@ -193,7 +193,7 @@
     "        # Determine the number of pages (only on first page request)\n",
     "        if (reqs == 0):\n",
     "            total_results = data[\"total\"]\n",
-    "            total_pages = (int(math.ceil(total_results/100.0)) * 100) / 100\n",
+    "            total_pages = (int(math.ceil(total_results/float(per_page_default))) * per_page_default) / per_page_default\n",
     "            if (total_pages > pages):\n",
     "                pages = total_pages\n",
     "        # Grab the 'hits' into lists\n",
@@ -243,48 +243,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "root\n",
-      " |-- uuid: string (nullable = false)\n",
-      " |-- date: timestamp (nullable = false)\n",
-      " |-- signature: string (nullable = false)\n",
-      " |-- platform: string (nullable = true)\n",
-      " |-- contains_memory_report: boolean (nullable = true)\n",
-      " |-- oom_allocation_size: long (nullable = true)\n",
-      " |-- system_memory_use_percentage: integer (nullable = true)\n",
-      " |-- total_virtual_memory: long (nullable = true)\n",
-      " |-- available_virtual_memory: long (nullable = true)\n",
-      " |-- total_page_file: long (nullable = true)\n",
-      " |-- available_page_file: long (nullable = true)\n",
-      " |-- total_physical_memory: long (nullable = true)\n",
-      " |-- available_physical_memory: long (nullable = true)\n",
-      " |-- largest_free_vm_block: string (nullable = true)\n",
-      " |-- largest_free_vm_block_int: long (nullable = true)\n",
-      " |-- tiny_block_size: long (nullable = true)\n",
-      " |-- write_combine_size: long (nullable = true)\n",
-      " |-- shutdown_progress: string (nullable = true)\n",
-      " |-- ipc_channel_error: string (nullable = true)\n",
-      " |-- user_comments: string (nullable = true)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "get_crashstats_by_day(date_format, DEBUG, target_date)"
    ]
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python2"
   },
@@ -298,7 +270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/reports/crash_stats_oom/getting-crash-stats-for-OOM-data-to-S3.ipynb
+++ b/reports/crash_stats_oom/getting-crash-stats-for-OOM-data-to-S3.ipynb
@@ -20,7 +20,8 @@
     "import urllib\n",
     "import math\n",
     "import datetime as dt\n",
-    "from pyspark.sql.types import *\n"
+    "from pyspark.sql.types import *\n",
+    "import boto3.s3"
    ]
   },
   {
@@ -54,7 +55,29 @@
     "    \"\"\" Return the int representation of obj, or None \"\"\"\n",
     "    if obj is None:\n",
     "        return None\n",
-    "    return int(obj)\n"
+    "    return int(obj)\n",
+    "\n",
+    "\n",
+    "def get_token_from_s3():\n",
+    "    \"\"\" Get socorro token from data already saved to s3 \"\"\"\n",
+    "    data_bucket = \"net-mozaws-prod-us-west-2-pipeline-analysis\"\n",
+    "    s3path = \"ddurst/oom\"\n",
+    "    filename = \"oom.tkn\"\n",
+    "    key = \"{}/{}\".format(s3path, filename)\n",
+    "\n",
+    "    s3 = boto3.resource('s3')\n",
+    "\n",
+    "    try:\n",
+    "        obj = s3.Object(data_bucket, key)\n",
+    "    except botocore.exceptions.ClientError as e:\n",
+    "        # If the file wasn't there, that's ok. Otherwise, abort!\n",
+    "        if e.response['Error']['Code'] != \"404\":\n",
+    "            raise e\n",
+    "        else:\n",
+    "            print \"Did not find an existing file at '{}'\".format(key)\n",
+    "\n",
+    "    token = obj.get()['Body'].read()\n",
+    "    return token\n"
    ]
   },
   {
@@ -147,8 +170,11 @@
     "    stop_date = (dt.datetime.strptime(start_date, format) +\n",
     "                 dt.timedelta(days=1)).strftime(format)\n",
     "\n",
+    "    token = get_token_from_s3()\n",
+    "\n",
     "    headers = {\n",
     "        'Accept': 'application/json',\n",
+    "        'Auth-Token': token,\n",
     "        'Content-Type': 'application/json; charset=UTF-8'\n",
     "    }\n",
     "    target = 'https://crash-stats.mozilla.com/api/SuperSearch/'\n",
@@ -242,14 +268,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "get_crashstats_by_day(date_format, DEBUG, target_date)"
+    "get_crashstats_by_day(date_format, DEBUG)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This ipynb has been modified in a few ways: upped the per page limit, using an Auth Token, pulling the token from S3.

@mreid-moz This *should* cover everything we've discussed, but I've been away from this for a while, so if anything should be changed about it, let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-services/data-pipeline/248)
<!-- Reviewable:end -->
